### PR TITLE
docs(0.10.x) Add warning about case-sensitivity

### DIFF
--- a/app/docs/0.10.x/getting-started/adding-your-api.md
+++ b/app/docs/0.10.x/getting-started/adding-your-api.md
@@ -20,6 +20,8 @@ helpful for learning how Kong proxies your API requests.
 Kong exposes a [RESTful Admin API][API] on port `:8001` for managing the
 configuration of your Kong instance or cluster.
 
+Kong is case-sensitive; therefore, make sure to have your hosts and upstream_url in lowercase.
+
 1. ### Add your API using the Admin API
 
     Issue the following cURL request to add your first API ([Mockbin][mockbin])


### PR DESCRIPTION
There are issues with case-sensitivity of Kong when dealing with AWS ELBs and basically situations, when URL is given with capital case letters.
In other words, having URLs in uppercase and then calling Kong APIs using those specified URLs in either `hosts` or `upstream_url` results in an error, since Kong thinks there is no API due to URL "differences"