### PR TITLE
docs(plugins) remove the "open an issue" button

### DIFF
--- a/app/plugins/index.html
+++ b/app/plugins/index.html
@@ -5,7 +5,6 @@ layout: default
 header_title: Plugins
 header_icon: /assets/images/icons/icn-plugins.svg
 header_caption: Extend your stack with powerful plugins configurable per Service, API and Consumer.
-header_btn_text: Suggest Plugin
 breadcrumbs: null
 ---
 

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -66,9 +66,6 @@ defaults:
       path: 'plugins'
     values:
       layout: 'plugin'
-      header_btn_text: Report Bug
-      header_btn_href: https://github.com/Mashape/kong/issues/new
-      header_btn_target: _blank
       id: page-plugin
       breadcrumbs: null
       nav:


### PR DESCRIPTION
We're reevaluating our strategy for community management.

For now we want to leave github issues for *bugs*, not general
questions or suggestions. At the same time the gitter chat lacks
permanency and the mailing list visibility. While we decide what
to do, we've decided to just hide the button.