### PR TITLE
docs(admin) remove 'plugin name or id' from /apis/:api/plugins/:plugin

### DIFF
--- a/app/docs/0.10.x/admin-api.md
+++ b/app/docs/0.10.x/admin-api.md
@@ -964,12 +964,12 @@ HTTP 200 OK
 
 #### Endpoint
 
-<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to update the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to update on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to update on this API
 
 #### Request Body
 
@@ -1028,12 +1028,12 @@ See POST and PATCH responses.
 
 #### Endpoint
 
-<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to delete the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to delete on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to delete on this API
 
 #### Response
 

--- a/app/docs/0.11.x/admin-api.md
+++ b/app/docs/0.11.x/admin-api.md
@@ -886,12 +886,12 @@ HTTP 200 OK
 
 #### Endpoint
 
-<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint patch">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to update the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to update on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to update on this API
 
 #### Request Body
 
@@ -955,12 +955,12 @@ See POST and PATCH responses.
 
 #### Endpoint
 
-<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin name or id}</div>
+<div class="endpoint delete">/apis/{api name or id}/plugins/{plugin id}</div>
 
 Attributes | Description
 ---:| ---
 `api name or id`<br>**required** | The unique identifier **or** the name of the API for which to delete the plugin configuration
-`plugin name or id`<br>**required** | The unique identifier **or** the name of the plugin configuration to delete on this API
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to delete on this API
 
 #### Response
 


### PR DESCRIPTION
endpoint

We mistakenly document that `/apis/{api name or id}/plugins/{plugin name
or id}` is a valid endpoint for 0.10 and 0.11 versions.

The correct endpoint is `/apis/{api name or id}/plugins/{plugin id}`.

See
https://github.com/Kong/kong/commit/7b2523f78751c661c7d2d3f612df8046292cbdcf
which was a revert commit for a previous commit introducing such "plugin
by name".