### PR TITLE
docs(basic-auth) add 2 new endpoints to list basic-auths

### DIFF
--- a/app/plugins/basic-authentication.md
+++ b/app/plugins/basic-authentication.md
@@ -15,6 +15,8 @@ nav:
       - label: Create a Credential
       - label: Using the Credential
       - label: Upstream Headers
+      - label: Paginate through the basic-auth Credentials
+      - label: Retrieve the Consumer associated with a Credential
 ---
 
 Add Basic Authentication to your APIs, with username and password protection. The plugin will check for valid credentials in the `Proxy-Authorization` and `Authorization` header (in this order).
@@ -118,6 +120,80 @@ When a client has been authenticated, the plugin will append some headers to the
 * `X-Anonymous-Consumer`, will be set to `true` when authentication failed, and the 'anonymous' consumer was set instead.
 
 You can use this information on your side to implement additional logic. You can use the `X-Consumer-ID` value to query the Kong Admin API and retrieve more information about the Consumer.
+
+### Paginate through the basic-auth Credentials
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This endpoint was introduced in Kong 0.11.2.
+</div>
+
+You can retrieve all the basic-auth Credentials for all the Consumers using
+the following request:
+
+```bash
+$ curl -X GET http://kong:8001/basic-auths
+
+{
+    "total": 3,
+    "data": [
+        {
+            "created_at": 1511379926000,
+            "id": "805520f6-842b-419f-8a12-d1de8a30b29f",
+            "password": "37b1af03d3860acf40bd9c681aa3ef3f543e49fe",
+            "username": "baz",
+            "consumer_id": "5e52251c-54b9-4c10-9605-b9b499aedb47"
+        },
+        {
+            "created_at": 1511379863000,
+            "id": "8edfe5c7-3151-4d92-971f-3faa5e6c5d7e",
+            "password": "451b06c564a06ce60874d0ea2f542fa8ed26317e",
+            "username": "foo",
+            "consumer_id": "89a41fef-3b40-4bb0-b5af-33da57a7ffcf"
+        },
+        {
+            "created_at": 1511379877000,
+            "id": "f11cb0ea-eacf-4a6b-baea-a0e0b519a990",
+            "password": "451b06c564a06ce60874d0ea2f542fa8ed26317e",
+            "username": "foobar",
+            "consumer_id": "89a41fef-3b40-4bb0-b5af-33da57a7ffcf"
+        }
+    ]
+}
+```
+
+You can filter the list using the following query parameters:
+
+Attributes | Description
+---:| ---
+`id`<br>*optional*                       | A filter on the list based on the basic-auth credential `id` field.
+`username`<br>*optional*                 | A filter on the list based on the basic-auth credential `username` field.
+`consumer_id`<br>*optional*              | A filter on the list based on the basic-auth credential `consumer_id` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional*                   | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+### Retrieve the Consumer associated with a Credential
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This endpoint was introduced in Kong 0.11.2.
+</div>
+
+It is possible to retrieve a [Consumer][consumer-object] associated
+with a basic-auth Credential using the following request:
+
+```bash
+curl -X GET http://kong:8001/basic-auths/{username or id}/consumer
+
+{
+   "created_at":1507936639000,
+   "username":"foo",
+   "id":"c0d92ba9-8306-482a-b60d-0cfdd2f0e880"
+}
+```
+
+`username or id`: The `id` or `username` property of the basic-auth
+credential for which to get the associated [Consumer][consumer-object].
+Note that the `username` accepted here is **not** the 
+`username` property of a Consumer.
 
 [api-object]: /docs/latest/admin-api/#api-object
 [configuration]: /docs/latest/configuration


### PR DESCRIPTION
* `/basic-auths/` to paginate through all basic-auth credentials
* `/basic-auths/:credential_id_or_username/consumer` to retrieve the
Consumer associated with a credential

See: https://github.com/Kong/kong/pull/2998