### PR TITLE
Added _ as option for config.key_names

### DIFF
--- a/app/plugins/key-authentication.md
+++ b/app/plugins/key-authentication.md
@@ -1,4 +1,4 @@
----
+=---
 id: page-plugin
 title: Plugins - Key Authentication
 header_title: Key Authentication
@@ -56,7 +56,7 @@ blacklist groups of users.
 form parameter                   | default | description
 ---                              | ---     | ---
 `name`                           |         | The name of the plugin to use, in this case: `key-auth`.
-`config.key_names`<br>*optional* | `apikey`| Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9] and [-].
+`config.key_names`<br>*optional* | `apikey`| Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
 `config.key_in_body`             | `false` | If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.
 `config.hide_credentials`<br>*optional* | `false` | An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.
 `config.anonymous`<br>*optional*        | ``      | An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.


### PR DESCRIPTION
A customer pointed this out and I tested and confirmed. You can also use an underscore [_] for that parameter