### PR TITLE
fix(key-auth) fix page template to render page correctly

### DIFF
--- a/app/plugins/key-authentication.md
+++ b/app/plugins/key-authentication.md
@@ -1,4 +1,4 @@
-----
+---
 id: page-plugin
 title: Plugins - Key Authentication
 header_title: Key Authentication


### PR DESCRIPTION
https://github.com/Kong/getkong.org/commit/b8c09d989b08525df433ef3200e529b28c25ffb5 added an extra hyphen which does not render
the [page](https://getkong.org/plugins/key-authentication) correctly.