### PR TITLE
docs(auth-ldap) use standard LDAP port in example

### DIFF
--- a/app/plugins/ldap-authentication.md
+++ b/app/plugins/ldap-authentication.md
@@ -27,7 +27,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     --data "name=ldap-auth" \
     --data "config.hide_credentials=true" \
     --data "config.ldap_host=ldap.example.com" \
-    --data "config.ldap_port=398" \
+    --data "config.ldap_port=389" \
     --data "config.base_dn=dc=example,dc=com" \
     --data "config.attribute=cn" \
     --data "config.cache_ttl=60" \


### PR DESCRIPTION
Use [the standard LDAP port (TCP/389)](https://wiki.wireshark.org/LDAP) in the example instead of 398.