### PR TITLE
docs(0.13.x/admin-api) add node_id to `/` endpoint

### DIFF
--- a/app/docs/0.12.x/admin-api.md
+++ b/app/docs/0.12.x/admin-api.md
@@ -139,6 +139,7 @@ HTTP 200 OK
 ```json
 {
     "hostname": "",
+    "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
     "lua_version": "LuaJIT 2.1.0-alpha",
     "plugins": {
         "available_on_server": [
@@ -156,6 +157,8 @@ HTTP 200 OK
 }
 ```
 
+* `node_id`: A UUID representing the running Kong node. This UUID is randomly generated when Kong starts, so the node will have a different `node_id` each
+  time it is restarted.
 * `available_on_server`: Names of plugins that are installed on the node.
 * `enabled_in_cluster`: Names of plugins that are enabled/configured. That is, the plugins configurations currently in the datastore shared by all Kong nodes.
 

--- a/app/docs/0.13.x/admin-api.md
+++ b/app/docs/0.13.x/admin-api.md
@@ -197,6 +197,7 @@ HTTP 200 OK
 ```json
 {
     "hostname": "",
+    "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
     "lua_version": "LuaJIT 2.1.0-beta3",
     "plugins": {
         "available_on_server": [
@@ -214,6 +215,8 @@ HTTP 200 OK
 }
 ```
 
+* `node_id`: A UUID representing the running Kong node. This UUID is randomly generated when Kong starts, so the node will have a different `node_id` each
+  time it is restarted.
 * `available_on_server`: Names of plugins that are installed on the node.
 * `enabled_in_cluster`: Names of plugins that are enabled/configured. That is, the plugins configurations currently in the datastore shared by all Kong nodes.
 


### PR DESCRIPTION
Includes the commit for 0.12.x as well (should it?)