### PR TITLE
Order of releases in the docs dropdown

### DIFF
--- a/app/_layouts/docs.html
+++ b/app/_layouts/docs.html
@@ -23,7 +23,7 @@ id: documentation
         </button>
 
         <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
-          {% for ver in site.data.kong_versions %}
+          {% for ver in site.data.kong_versions reversed %}
             {% unless page.kong_version == ver.release %}
               <li>
                 <a href="/docs/{{ver.release}}"{% if ver.release == page.kong_version %} class="active"{% endif %}>


### PR DESCRIPTION
This PR adds reversed to the loop of releases in the docs dropdown

Before:

![before](https://d2ffutrenqvap3.cloudfront.net/items/06420r3q161i0I1p2B1w/Image%202018-02-23%20at%208.16.31%20AM.png)

After:

![after](https://d2ffutrenqvap3.cloudfront.net/items/2C3R0L2j2J3E1R3C1X1F/Image%202018-02-23%20at%208.15.59%20AM.png)