### PR TITLE
docs(plugins) update the plugin layout to generate "Getting Started"

### DIFF
--- a/app/_layouts/plugin.html
+++ b/app/_layouts/plugin.html
@@ -5,13 +5,127 @@ id: page-plugin
 header_btn_text: Report Bug
 header_btn_href: mailto:support@mashape.com?subject={{ page.header_title }} Plugin Bug
 breadcrumbs: null
+
 ---
+
+{% capture config_required_fields %}{%
+  for field in page.params.config %}{%
+  if field.required %} \
+    --data "{{ field.name }}={{ field.default }}"
+{% endif %}{% endfor %}{% endcapture %}
+
+{% if page.params.api_id %}
+{% capture plugin_config_for_api %}
+Configuring on top of an [API](/docs/latest/admin-api/#api-object) by executing the following request on your Kong server:
+
+```bash
+$ curl -X POST http://kong:8001/apis/{api}/plugins \
+    --data "name={{page.params.name}}" {{ config_required_fields }}
+```
+
+* `api`: either id or name of the API that this plugin configuration will target.
+{% endcapture %}
+{% endif %}
+
+{% if page.params.service_id %}
+{% capture plugin_config_for_service %}
+Configure on top of a [Service](/docs/latest/admin-api/#service-object) by executing the following request on your Kong server:
+
+```bash
+$ curl -X POST http://kong:8001/services/{service}/plugins \
+    --data "name={{page.params.name}}" {{ config_required_fields }}
+```
+
+* `service`: the id or name of the Service that this plugin configuration will target.
+{% endcapture %}
+{% endif %}
+
+{% if page.params.route_id %}
+{% capture plugin_config_for_route %}
+Configure on top of a [Route](/docs/latest/admin-api/#Route-object) with:
+
+```bash
+$ curl -X POST http://kong:8001/routes/{route_id}/plugins \
+    --data "name={{page.params.name}}" {{ config_required_fields }}
+```
+
+* `route_id`: the id of the Route that this plugin configuration will target.
+{% endcapture %}
+{% endif %}
+
+{% if page.params.consumer_id %}
+{% capture plugin_config_for_consumer %}
+You can use the `/plugins` endpoint to target [Consumers](/docs/latest/admin-api/#Consumer-object):
+
+```bash
+$ curl -X POST http://kong:8001/plugins \
+    --data "name={{page.params.name}}" \
+    --data "consumer_id={consumer_id}" {{ config_required_fields }}
+```
+
+Where `consumer_id`: The id of the Consumer we want to associate with this plugin.
+{% if page.params.service_id or page.params_route_id or page.params.api_id %}
+  You can combine adding `consumer_id` and {% if page.params.service_id %}
+    `service_id`
+  {% elsif page.params.route_id %}
+    `route_id`
+  {% elsif page.params.api_id %}
+    `api_id`
+  {% endif %} in the same request.
+{% endif %}
+
+{% if page.params.name != "acl" %}
+  Once applied, any user with a valid credential can access the Service/API.
+  To restrict usage to only some of the authenticated users, also add the
+  [ACL](/plugins/acl/) plugin (not covered here) and create whitelist or
+  blacklist groups of users.
+{% endif %}
+{% endcapture %}
+{% endif %}
+
+{% capture params_table %}
+<table>
+  <thead>
+    <tr><th>form parameter</th><th>default</th><th>description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>name</code></td><td></td><td>The name of the plugin to use, in this case <code>{{ page.params.name }}</code></td></tr>
+    {% if page.params.api_id %}
+      <tr><td><code>api_id</code></td><td></td><td>The id of the API which this plugin will target.</td></tr>
+    {% endif %}
+    {% if page.params.service_id %}
+      <tr><td><code>service_id</code></td><td></td><td>The id of the Service which this plugin will target.</td></tr>
+    {% endif %}
+    {% if page.params.route_id %}
+      <tr><td><code>route_id</code></td><td></td><td>The id of the Route which this plugin will target.</td></tr>
+    {% endif %}
+    {% if page.params.consumer_id %}
+      <tr><td><code>consumer_id</code></td><td></td><td>The id of the Consumer which this plugin will target.</td></tr>
+    {% endif %}
+    {% for field in page.params.config %}
+      <tr>
+        <td><code>{{ field.name }}</code>{% if field.required != true %}<br><em>optional</em>{% endif %}</td>
+        <td>{% if field.default %}<code>{{ field.default }}</code>{% endif %}</td>
+        <td>{{ field.description | markdownify }}</td>
+      </td>
+    {% endfor %}
+  </tbody>
+</table>
+{% endcapture %}
 
 <div class="page {{ page.id }}">
   {% include header.html %}
 
   <div class="container">
     <aside class="page-navigation">
+
+      <nav>
+        <h5>Getting Started</h5>
+        <ul>
+          <li><a href="#terminology">Terminology</a></li>
+          <li><a href="#configuration">Configuration</a></li>
+        </ul>
+      </nav>
 
       {% for nav in page.nav %}
         <nav>
@@ -43,6 +157,53 @@ breadcrumbs: null
     <div class="page-content-container">
       <div class="page-content">
         <div class="content">
+
+          {{ page.description | markdownify }}
+
+          <hr>
+
+          <h2 id="terminology">Terminology</h2>
+          <ul>
+            <li><code>plugin</code>: a plugin executing actions inside Kong before or after a request has been proxied to the upstream API.</li>
+
+            {% if page.params.api_id %}
+              <li><code>api</code>: your upstream service placed behind Kong, for which Kong proxies requests to.</li>
+            {% endif %}
+            {% if page.params.service_id or page.params.route_id %}
+              <li><code>service</code>: The kong entity representing an external <em>upstream</em> API or microservice.</li>
+            {% endif %}
+            {% if page.params.route_id %}
+              <li><code>route</code>: The kong entity representing a way to map downstream requests to upstream services.</li>
+            {% endif %}
+            {% if page.params.consumer_id %}
+              <li><code>consumer</code>: a developer or machine using the api. When using Kong, a Consumer only communicates with Kong which proxies every call to the said, upstream api.</li>
+              <li><code>credential</code>: a unique string associated with a consumer, also referred to as an API key.</li>
+            {% endif %}
+          </ul>
+
+          <hr>
+
+          <h2 id="configuration">Configuration</h2>
+          {% if page.params.api_id %}
+            {{ plugin_config_for_api | markdownify }}
+          {% endif %}
+          {% if page.params.service_id %}
+            {{ plugin_config_for_service | markdownify }}
+          {% endif %}
+          {% if page.params.route_id %}
+            {{ plugin_config_for_route | markdownify }}
+          {% endif %}
+          {% if page.params.consumer_id %}
+            {{ plugin_config_for_consumer | markdownify }}
+          {% endif %}
+          <p>All plugins can be configured using the <code>/plugins</code> endpoint. A plugin which is not associated to any api, service, route or consumer is considered "global", and will be executed on every request.</p>
+
+          <p>Here's a list of all the parameters which can be used in this plugin's configuration: </p>
+
+          {{ params_table | markdownify }}
+
+          {{ page.params.extra | markdownify }}
+
           {{ content }}
         </div>
       </div>

--- a/app/plugins/key-authentication.md
+++ b/app/plugins/key-authentication.md
@@ -6,10 +6,6 @@ header_icon: /assets/images/icons/plugins/key-authentication.png
 breadcrumbs:
   Plugins: /plugins
 nav:
-  - label: Getting Started
-    items:
-      - label: Terminology
-      - label: Configuration
   - label: Usage
     items:
     - label: Create a Consumer
@@ -19,57 +15,48 @@ nav:
     - label: Upstream Headers
     - label: Paginate through the API keys
     - label: Retrieve the Consumer associated with an API key
+description: |
+  Add Key Authentication (also referred to as an API key) to your APIs, Services or Routes. Consumers then add their key either in a querystring parameter or a header to authenticate their requests.
+params:
+  name: key-auth
+  api_id: true
+  service_id: true
+  route_id: true
+  consumer_id: false
+  config:
+    - name: key_names
+      required: false
+      default: apikey
+      description: |
+        Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
+    - name: key_in_body
+      required: false
+      default: false
+      description: |
+        If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.
+    - name: hide_credentials
+      required: false
+      default: false
+      description: |
+        An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.
+    - name: anonymous
+      required: false
+      default:
+      description: |
+        An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
+    - name: run_on_preflight
+      required: false
+      default: true
+      description: |
+        A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests, if set to `false` then `OPTIONS` requests will always be allowed.
+  extra: |
+    Note that, according to their respective specifications, HTTP header names are treated as case _insensitive_, while HTTP query string parameter names are treated as case _sensitive_. Kong follows these specifications as designed, meaning that the `key_names` configuration values will be treated differently when searching the request header fields, versus searching the query string. Administrators are advised against defining case-sensitive `key_names` values when expecting the authorization keys to be sent in the request headers.
+
+    <div class="alert alert-warning">
+        <center>The option `config.run_on_preflight` is only available from version `0.11.1` and later</center>
+    </div>
+
 ---
-
-Add Key Authentication (also referred to as an API key) to your APIs. Consumers then add their key either in a querystring parameter or a header to authenticate their requests.
-
-----
-
-## Terminology
-
-- `api`: your upstream service placed behind Kong, for which Kong proxies requests to.
-- `plugin`: a plugin executing actions inside Kong before or after a request has been proxied to the upstream API.
-- `consumer`: a developer or service using the api. When using Kong, a Consumer only communicates with Kong which proxies every call to the said, upstream api.
-- `credential`: in the key-auth plugin context, a unique string associated with a consumer, also referred to as an API key.
-
-----
-
-## Configuration
-
-Configuring the plugin is straightforward, you can add it on top of an [API][api-object] by executing the following request on your Kong server:
-
-
-```bash
-$ curl -X POST http://kong:8001/apis/{api}/plugins \
-    --data "name=key-auth" \
-    --data "config.hide_credentials=true"
-```
-
-* `api`: The `id` or `name` of the API that this plugin configuration will target
-
-You can also apply it for every API using the `http://kong:8001/plugins/` endpoint. Read the [Plugin Reference](/docs/latest/admin-api/#add-plugin) for more information.
-
-Once applied, any user with a valid credential can access the service/API.
-To restrict usage to only some of the authenticated users, also add the
-[ACL](/plugins/acl/) plugin (not covered here) and create whitelist or
-blacklist groups of users.
-
-form parameter                   | default | description
----                              | ---     | ---
-`name`                           |         | The name of the plugin to use, in this case: `key-auth`.
-`config.key_names`<br>*optional* | `apikey`| Describes an array of comma separated parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name.<br>*note*: the key names may only contain [a-z], [A-Z], [0-9], [_] and [-].
-`config.key_in_body`             | `false` | If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.
-`config.hide_credentials`<br>*optional* | `false` | An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.
-`config.anonymous`<br>*optional*        | ``      | An optional string (consumer uuid) value to use as an "anonymous" consumer if authentication fails. If empty (default), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` attribute which is internal to Kong, and **not** its `custom_id`.
-`config.run_on_preflight`<br>*optional* | `true`  | A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests, if set to `false` then `OPTIONS` requests will always be allowed.
-
-Note that, according to their respective specifications, HTTP header names are treated as case _insensitive_, while HTTP query string parameter names are treated as case _sensitive_. Kong follows these specifications as designed, meaning that the `key_names` configuration values will be treated differently when searching the request header fields, versus searching the query string. Administrators are advised against defining case-sensitive `key_names` values when expecting the authorization keys to be sent in the request headers.
-
-<div class="alert alert-warning">
-    <center>The option `config.run_on_preflight` is only available from version `0.11.1` and later</center>
-</div>
-
-----
 
 ## Usage
 


### PR DESCRIPTION
Since this change modifies the plugins layout, all plugins will have to be adapted to using it (if this is not desired, we can use two different plugin layouts).

There are 4 steps to transform a plugin:

1. Move the "top description" out of the "content" and into a field called `description` in the yml front of the file.
2. Add a section called `params` to the yml front. It needs the following fields:
  * `name` (the name of the plugin, i.e. `key-auth`).
  * `api_id` true if this plugin can be attached to APIs, false if it doesnt
  * `service_id` true if this plugin can be attached to services, false otherwise
  * `route_id` ditto for routes
  * `config`: This will be a list of n fields, with 4 properties each. Usually
    you can get this list by reformatting the "markdown table" at the end of 
    the legacy "description" section of the page you are transforming.
    * `name`: The name of the field (like `hide_credentials`)
    * `required`: true or false. If required, they will be included on the getting
       started examples. If false, it will be marked as optional on the field table.
    * `default`: The default value, if any.
    * `description`: Text. Notice that yaml can be picky with special characters
       inside descriptions. If you are having trouble, use `|` and start the 
       description indented under the `description: |`, as shown on this PR. 
  * `extra` accepts a markdown field which will be rendered after the table of 
    fields (see example on this PR)
3. Remove the `Getting Started` section from the `nav` item in the yml front.
4. Remove the "Terminology" and "Configuration" sections from the content. Those sections are now generated automatically.

Here's a screenshot of the generated top - everything up to "Usage" is generated from the yml:

![auth](https://user-images.githubusercontent.com/63131/37355814-ecefa0d8-26e4-11e8-9674-48f41750a861.png)



    
