### PR TITLE
docs(install) update example to use PSQL 9.5

### DIFF
--- a/app/install/docker.md
+++ b/app/install/docker.md
@@ -28,7 +28,7 @@ Here is a quick example showing how to link a Kong container to a Cassandra or P
                   -p 5432:5432 \
                   -e "POSTGRES_USER=kong" \
                   -e "POSTGRES_DB=kong" \
-                  postgres:9.4
+                  postgres:9.5
     ```
 
 2. **Prepare your database**


### PR DESCRIPTION
Minimum recommended PostgreSQL version is 9.5 since Kong 0.12.x