### PR TITLE
miscelaneous fixes in EE docs

### DIFF
--- a/app/docs/enterprise/0.31-x/plugins/request-transformer.md
+++ b/app/docs/enterprise/0.31-x/plugins/request-transformer.md
@@ -30,21 +30,21 @@ You can also apply it for every API using the http://kong:8001/plugins/ endpoint
 | Form Parameter | Description
 | --------- | -----------
 |`consumer_id`<br>*optional* | Name of the plugin to use, in this case:request-transformer-advanced consumer_id optional	The consumer ID that this plugin configuration will target. This value can only be used if [authentication has been enabled](/about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?)  so that the system can identify the user making the request.
-| `config.http_method` <br>*optional* | Changes the HTTP method for the upstream request.
+|`config.http_method` <br>*optional* | Changes the HTTP method for the upstream request.
 |`config.remove.headers` <br>*optional* | List of header names. Unset the headers with the given name.
-| `config.remove.querystring`<br>*optional* | List of querystring names. Remove the querystring if it is present.
-| `config.remove.body`<br>*optional* | List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
+|`config.remove.querystring`<br>*optional* | List of querystring names. Remove the querystring if it is present.
+|`config.remove.body`<br>*optional* | List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
 |`config.remove.headers` <br>*optional* | List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
-|`config.replace.querystring`<br>*optional* | List of queryname:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
+|`config.replace.querystring`<br>*optional* | List of queryname:value pairs. If and only if the querystring name is already set, replace its old value with the new one. Ignored if the header is not already set.
 |`config.replace.uri`<br>*optional* | Updates the upstream request URI with given value. This value can only be used to update the path part of the uri, not the scheme, nor the hostname.
 |`config.replace.body`<br>*optional* | List of paramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.
 |`config.rename.headers`<br>*optional* | List of headername:value pairs. If and only if the header is already set, rename the header. The value is unchanged. Ignored if the header is not already set.
 |`config.rename.querystring`<br>*optional* | List of queryname:value pairs. If and only if the field name is already set, rename the field name. The value is unchanged. Ignored if the field name is not already set.
 |`config.rename.body`<br>*optional* | List of parameter name:value pairs. Rename the parameter name if and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
 |`config.add.headers`<br>*optional* | List of headername:value pairs. If and only if the header is not already set, set a new header with the given value. Ignored if the header is already set.
-|`config.add.querystring`<br>*optional* | List of queryname:value pairs. If and only if the querystring is not already set, set a new querystring with the given value. Ignored if the header is already set.
-|`config.add.body`<br>*optional* | List of pramname:value pairs. If and only if content-type is one the following [`application/json, multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is not present, add a new parameter with the given value to form-encoded body. Ignored if the parameter is already present.
-|`config.add.headers`<br>*optional* | List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
+|`config.add.querystring`<br>*optional* | List of queryname:value pairs. If and only if the querystring name is not already set, set a new querystring with the given value. Ignored if the querystring name is already set.
+|`config.add.body`<br>*optional* | List of paramname:value pairs. If and only if content-type is one the following [`application/json, multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is not present, add a new parameter with the given value to form-encoded body. Ignored if the parameter is already present.
+|`config.append.headers`<br>*optional* | List of headername:value pairs. If the header is not set, set it with the given value. If it is already set, a new header with the same name and the new value will be set.
 |`config.append.querystring`<br>*optional* | List of queryname:value pairs. If the querystring is not set, set it with the given value. If it is already set, a new querystring with the same name and the new value will be set.
 |`config.append.body`<br>*optional* | List of paramname:value pairs. If the content-type is one the following [`application/json`, `application/x-www-form-urlencoded`], add a new parameter with the given value if the parameter is not present, otherwise if it is already present, the two values (old and new) will be aggregated in an array.
 
@@ -163,11 +163,20 @@ $ curl -X POST http://localhost:8001/apis/mockbin/plugins \
 | h1: v1 | h1: v1, h2: v1 
 | h3: v1 | h1: v1, h2: v1, h3: v1
 
-| Incoming Request Headers | Upstream Proxied Headers
+| Incoming Request Querystring | Upstream Proxied Querystring
 | --------- | -----------
-| \?q1=v1 | \?q1=v1&q2=v1<br>\?q1=v2&q2=v1
+| ?q1=v1 | ?q1=v1&q2=v1
+|        | ?q1=v2&q2=v1
 
 Append multiple headers and remove a body parameter:
+
+```
+$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+  --data "name=request-transformer-advanced" \
+  --data "config.add.headers=h1:v2,h2:v1" \
+  --data "config.remove.body=p1" \
+
+```
 
 | Incoming Request Headers | Upstream Proxied Headers
 | --------- | -----------
@@ -178,6 +187,16 @@ Append multiple headers and remove a body parameter:
 | p1=v1&p2=v1 | p2=v1
 | p2=v1 | p2=v1
 
+Add multiple headers and querystring parameters if not already set:
+
+```
+$ curl -X POST http://localhost:8001/apis/mockbin/plugins \
+  --data "name=request-transformer-advanced" \
+  --data "config.add.headers=h1:v1,h2:v1" \
+  --data "config.add.querystring=q1:v2,q2:v1" \
+
+```
+
 | Incoming Request Headers | Upstream Proxied Headers
 | --------- | -----------
 | h1: v1 | h1: v1, h2: v1
@@ -185,4 +204,5 @@ Append multiple headers and remove a body parameter:
 
 | Incoming Request Querystring | Upstream Proxied Querystring
 | --------- | -----------
-| \?q1=v1 | \?q1=v1&q2=v1<br>\?q1=v2&q2=v1
+| ?q1=v1 | ?q1=v1&q2=v1
+|        | ?q1=v2&q2=v1

--- a/app/docs/enterprise/0.31-x/setting-up-admin-api-rbac.md
+++ b/app/docs/enterprise/0.31-x/setting-up-admin-api-rbac.md
@@ -146,7 +146,7 @@ The default RBAC roles and permissions shipped with Kong are a great starting po
 
 Additionally, third-party plugin developers can register their own Admin API RBAC resources as part of the [Admin API extension](/docs/latest/plugin-development/admin-api). This is done by defining a "resource" value associated with each API endpoint, like so:
 
-```
+```lua
 return {
   ["/mock/api/endpoint/"] = {
     resource = "mock",
@@ -159,7 +159,7 @@ return {
 
 Additionally, a custom migration is needed to register this resource with Kong. This would look something like the following:
 
-```
+```lua
 {
    name = "2017-07-23-100000_rbac_mock_resources",
    up = function(_, _, dao)


### PR DESCRIPTION
I bumped into the highlighting syntax error in the RBAC docs, then inspired by our seaside conversation on fixing docs, jumped in to fix it. While I was at it, I noticed a stray backslash in `request-transformer-advanced` and fell into a bit of a rabbit hole fixing that plugin's docs. :)