### PR TITLE
docs(0.13.x) use /services/:service/plugins in examples

### DIFF
--- a/app/docs/0.13.x/auth.md
+++ b/app/docs/0.13.x/auth.md
@@ -59,8 +59,6 @@ the corresponding route:
       --data 'url=http://mockbin.org/request'
     ```
 
-    Be sure to note the Service `id` - you'll need it in step 2.
-
     Add a route to the Service:
 
     ```bash
@@ -77,9 +75,8 @@ the corresponding route:
 
     ```bash
     $ curl -i -X POST \
-      --url http://localhost:8001/plugins/ \
-      --data 'name=key-auth' \
-      --data 'service_id=<the-service-id>'
+      --url http://localhost:8001/services/example-service/plugins/ \
+      --data 'name=key-auth'
     ```
 
     Be sure to note the created Plugin `id` - you'll need it in step 5.

--- a/app/docs/0.13.x/clustering.md
+++ b/app/docs/0.13.x/clustering.md
@@ -121,12 +121,16 @@ On node `A`, we add a Service and a Route:
 ```bash
 # node A
 $ curl -X POST http://127.0.0.1:8001/services \
-    --data "name=example" \
+    --data "name=example-service" \
     --data "url=http://example.com"
 
-$ curl -X POST http://127.0.0.1:8001/services/example/routes \
-    --data "paths[]=example.com"
+$ curl -X POST http://127.0.0.1:8001/services/example-service/routes \
+    --data "paths[]=/example"
 ```
+
+(Note that we used `/services/example-service/routes` as a shortcut: we
+could have used the `/routes` endpoint instead, but then we would need to
+pass `service_id` as an argument, with the UUID of the new service.)
 
 A request to the Proxy port of both node `A` and `B` will cache this Service, and
 the fact that no plugin is configured on it:
@@ -149,9 +153,8 @@ Now, say we add a plugin to this Service via node `A`'s Admin API:
 
 ```bash
 # node A
-$ curl -X POST http://127.0.0.1:8001/plugins \
+$ curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
     --data "name=example-plugin"
-    --data "service_id=<example_service_id>"
 ```
 
 Because this request was issued via node `A`'s Admin API, node `A` will locally

--- a/app/docs/0.13.x/getting-started/enabling-plugins.md
+++ b/app/docs/0.13.x/getting-started/enabling-plugins.md
@@ -32,9 +32,8 @@ from unauthorized use.
 
     ```bash
     $ curl -i -X POST \
-      --url http://localhost:8001/plugins/ \
-      --data 'name=key-auth' \
-      --data 'service_id=<your-service-id>'
+      --url http://localhost:8001/services/example-service/plugins/ \
+      --data 'name=key-auth'
     ```
 
     **Note:** This plugin also accepts a `config.key_names` parameter, which

--- a/app/docs/0.13.x/health-checks-circuit-breakers.md
+++ b/app/docs/0.13.x/health-checks-circuit-breakers.md
@@ -166,7 +166,7 @@ health checker that the target should be enabled again, via an
 Admin API endpoint:
 
 ```bash
-$ curl -i -X POST http://localhost:8001/upstream/my_upstream/targets/10.1.2.3:1234/healthy
+$ curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
 HTTP/1.1 204 No Content
 ```
 

--- a/app/docs/0.13.x/plugin-development/plugin-configuration.md
+++ b/app/docs/0.13.x/plugin-development/plugin-configuration.md
@@ -23,9 +23,8 @@ Your plugin's configuration is being verified against your schema when a user is
 For example, a user performs the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/plugins/ \
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins/ \
     -d "name=my-custom-plugin" \
-    -d "service_id=<a-service-id>" \
     -d "config.foo=bar"
 ```
 
@@ -180,9 +179,8 @@ return {
 Such a configuration will allow a user to post the configuration to your plugin as follows:
 
 ```bash
-$ curl -X POST http://kong:8001/plugins \
-    -d "name=<my-custom-plugin>" \
-    -d "service_id=<the-service-id>" \
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+    -d "name=my-custom-plugin" \
     -d "config.environment=development" \
     -d "config.server.host=http://localhost"
 ```


### PR DESCRIPTION
Use `/services/:service/plugins` whenever possible in examples, instead of `/plugins`, since the latter requires the service ID to be used, and the former can use service name.

(Includes bonus unrelated commit with a backport from @thibaultcha's fix of the health endpoint from `docs/0.12.x` to `docs/0.13.x`.)
