### PR TITLE
docs(contributing) various improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,63 @@
-> You are reviewing the contributing document for getkong.org. If you want to know how to contribute to Kong itself, then please go [here](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md)
+> You are reviewing the contributing guidelines of getkong.org. If you want to
+> contribute to Kong itself, then please go
+> [here](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md).
 
 # Contributing to getkong.org 📜 🦍
 
 Hello, and welcome! Whether you are looking for help, trying to report a bug,
 thinking about getting involved in the project or about to submit a patch, this
-document is for you! Its intent is to be both an entry point for newcomers to
-the community (of all technical backgrounds), and a guide/reference for
-contributors and maintainers.
+document is for you!
 
 Consult the Table of Contents below, and jump to the desired section.
+
 
 ## Table of Contents
 
 - [Where to seek for help?](#where-to-seek-for-help)
 - [Where to report bugs?](#where-to-report-bugs)
-- [Contributing](#contributing)
-  - [Improving the documentation](#improving-the-documentation)
+- [Contributing to the documentation](#contributing-to-the-documentation)
   - [Submitting a patch](#submitting-a-patch)
     - [Git branches](#git-branches)
     - [Commit atomicity](#commit-atomicity)
     - [Commit message format](#commit-message-format)
-    - [Static linting](#linting)
+    - [Linting](#linting)
 
 
 ## Where to seek for help?
 
-See the [Kong Contributing Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-seek-for-help) for an overview of the channels at your disposal.
+Consult the [Kong Contributing
+Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-seek-for-help)
+for an overview of the communication channels at your disposal.
+
+[Back to TOC](#table-of-contents)
+
 
 ## Where to report bugs?
 
-If the bug is about the getkong.org website, please report it in this [repository's issues tracker](https://github.com/kong/getkong.org/issues/new). If the bug is related to Kong itself, please  see the [Kong Contributing Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-report-bugs).
+If the bug is about the https://getkong.org website itself, please report it
+in this [repository's issues
+tracker](https://github.com/kong/getkong.org/issues/new).
 
-## Contributing
+If the bug is related to Kong itself, please refer to the [Kong Contributing
+Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-report-bugs)
+instead.
 
-We welcome all kings of contributions, not only to Kong, but also to its documentation! If you wish to contribute to the documentation (by fixing a typo of making any other kind of improvement), please read the below section about [submitting a
-+patch](#submitting-a-patch).
+[Back to TOC](#table-of-contents)
 
-If you wish to contribute to Kong itself, see the [Kong Contributing Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing).
 
-### Improving the documentation
+## Contributing to the documentation
 
-When contributing, be weary of a few things:
+Improving the documentation is a most welcome form of contribution to the Kong
+community! You are welcome to suggest edits, improvements, or fix any typo
+you may find on this website. Please read the below section about
+[submitting a patch](#submitting-a-patch).
+
+If you wish to contribute to Kong itself (as opposed to the documentation
+website), then please consult the [Kong Contributing
+Guideline](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing)
+instead.
+
+When contributing, be wary of a few things:
 
 - The plugins documentation lives in the `app/plugins` directory. **This part
   of the documentation is not versioned**, which means that the plugins
@@ -51,8 +68,9 @@ When contributing, be weary of a few things:
   it for older versions as well.
   Example: if you fix a typo in `app/docs/0.10.x/configuration.md`, this typo
   may also be present in `app/docs/0.9.x/configuration.md`.
-- There are enterprise edition documents that live under `app/docs/enterprise/x.x-x`
-  and have a plugins section specific to EE which are versioned unlike CE plugins.
+- There are enterprise edition documents that live under
+  `app/docs/enterprise/x.x-x` and have a plugins section specific to EE which
+  are versioned unlike CE plugins.
 
 [Back to TOC](#table-of-contents)
 
@@ -64,7 +82,8 @@ Requests! If you are planning to develop a larger feature, come talk to us
 first!
 
 When contributing, please follow the guidelines provided in this document. They
-will cover topics such as the commit message format to use or how to run the linter.
+will cover topics such as the commit message format to use or how to run the
+linter.
 
 Once you have read them, and you are ready to submit your Pull Request, be sure
 to verify a few things:
@@ -86,28 +105,31 @@ you are probably the one in need of it. You must be prepared to apply changes
 to it if necessary.
 
 If your Pull Request was accepted, congratulations! You are now an official
-contributor of getkong.org. Your changes will be included in the subsequent release.
-Deploys are currently manually pushed via github pages, so please allow for some
-time for the changes to be persisted to the site.
+contributor of getkong.org and member of the Kong community.
+
+Your changes will be deployed as soon as a maintainer gets a chance to trigger
+a build, which should generally happen right after your patch was merged.
 
 [Back to TOC](#table-of-contents)
 
+
 #### Git branches
 
-Everything on `master` will get merged and pushed to github pages. Branch off of
-this branch for local development.
+In this repository, `master` represents the current state of the website, and
+should constantly be deployed. Branch off of this branch for local development.
 
 If you have write access to the GitHub repository, please follow the following
 naming scheme when pushing your branch(es):
 
-- `feat/foo-bar` for new features
-- `fix/foo-bar` for bug fixes (not including typos or content see [Type](#type) section below)
-- `tests/foo-bar` when the change concerns only the test suite
-- `refactor/foo-bar` when refactoring code without any behavior change
-- `style/foo-bar` when addressing some style issue
-- `docs/foo-bar` for updates to the README.md, docs, etc.
+- `docs/<ce|ee>-foo-bar` for updates to contents of the documentation (Markdown
+  files), README.md, or this file
+- `feat/foo-bar` for new website features e.g. Ruby, JavaScript, HTML, or CSS
+  changes to support a new feature
+- `fix/foo-bar` for website bug fixes (**not** including typos and other fixes
+  to the documentation itself, see the [Type](#type) section below)
 
 [Back to TOC](#table-of-contents)
+
 
 #### Commit atomicity
 
@@ -161,18 +183,18 @@ The type of your commit indicates what type of change this commit is about. The
 accepted types are:
 
 - **docs**: Changes made to any static content files associated with Kong CE
-  or EE documentation (including typo fixes), the README.md or this file.
-- **feat**: A new website feature e.g. Ruby, JavaScript, HTML, or CSS changes to
-  support a new feature.
-- **fix**: A website bug fix (related to the Ruby, JavaScript, HTML, or CSS assets).
-  Typos and other fixes to the _contents_ of the documentation (markdown files) are
-  not included in this scope.
-- **style**: CSS fixes, formatting, missing semi colons, �
+  or EE documentation (including typo fixes), the README.md or this file
+- **feat**: A new website feature e.g. Ruby, JavaScript, HTML, or CSS changes
+  to support a new feature
+- **fix**: A website bug fix (related to the Ruby, JavaScript, HTML, or CSS
+  assets). Typos and other fixes to the _contents_ of the documentation
+  (markdown files) are not included in this scope
+- **style**: CSS fixes, formatting, missing semi colons, :nail_care:
 - **refactor**: A code change that neither fixes a bug nor adds a feature, and
-  is too big to be considered `chore`.
-- **chore**: Maintenance changes related to code cleaning that isn't
-  considered part of a refactor, build process updates, dependency bumps, or
-  auxiliary tools and libraries updates (npm modules, Travis-ci, etc...).
+  is too big to be considered `chore`
+- **chore**: Maintenance changes related to code cleaning that isn't considered
+  part of a refactor, build process updates, dependency bumps, or auxiliary
+  tools and libraries updates (npm modules, Travis-ci, etc...)
 
 
 ##### Scope
@@ -180,38 +202,15 @@ accepted types are:
 The scope is the part of the codebase that is affected by your change. Choosing
 it is at your discretion, but here are some of the most frequent ones:
 
-- **`<ce or ee>/<section>`**: A change that affects the community edition or enterprise
-  edition docs and specifies which section.
-- **conf**: Configuration-related changes (new values, improvements...)
+- **`<ce or ee>/<section>`**: A change that affects the community edition or
+  enterprise edition docs and specifies which section.
+- **`admin`**: Changes related to the Admin API documentation
+- **`proxy`**: Changes related to the proxy documentation
+- **`conf`**: Changes related to the configuration file documentation (new
+  values, improvements...)
 - **`<plugin-name>`**: This could be `basic-auth`, or `ldap` for example
-- `*`: When the change affects too many parts of the codebase at once (this
+- **`*`**: When the change affects too many parts of the codebase at once (this
   should be rare and avoided)
-
-
-##### Subject
-
-Your subject should contain a succinct description of the change. It should be
-written so that:
-
-- It uses the present, imperative tense: "fix typo", and not "fixed" or "fixes"
-- It is **not** capitalized: "fix typo", and not "Fix typo"
-- It does **not** include a period. :smile:
-
-
-##### Body
-
-The body of your commit message should contain a detailed description of your
-changes. Ideally, if the change is significant, you should explain its
-motivation, the chosen implementation, and justify it.
-
-As previously mentioned, lines in the commit messages should not exceed 72
-characters.
-
-
-##### Footer
-
-The footer is the ideal place to link to related material about the change:
-related GitHub issues, Pull Requests, fixed bug reports, etc...
 
 
 ##### Examples
@@ -232,7 +231,8 @@ From #623
 
 #### Linting
 
-As mentioned in the guidelines, to submit a patch, the linter must succeed. You can run the linter like so:
+As mentioned in the guidelines, to submit a patch, the linter must succeed. You
+can run the linter like so:
 
 ```
 $ npm run test


### PR DESCRIPTION
* improve phrasing in various places
* respect 80 col limit
* more git commit format scopes and context
* add missing ToC links
* remove git instructions that seem "extraneous" for a simple
  documentation website (they apply better to a complex codebase like that
  of Kong/kong where those excerpts were taken from)