### PR TITLE
Trial callouts

### DIFF
--- a/app/install/aws-linux.md
+++ b/app/install/aws-linux.md
@@ -13,6 +13,8 @@ Start by downloading the following package specifically built for the Amazon Lin
 
 - [Download]({{ site.links.download }}/kong-community-edition-aws/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.aws.rpm)
 
+**Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
+
 ----
 
 ### Installation

--- a/app/install/centos.md
+++ b/app/install/centos.md
@@ -14,6 +14,8 @@ Start by downloading the corresponding package for your configuration:
 - [CentOS 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/6/kong-community-edition-{{site.data.kong_latest.version}}.el6.noarch.rpm)
 - [CentOS 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-{{site.data.kong_latest.version}}.el7.noarch.rpm)
 
+**Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
+
 ### YUM Repositories
 
 You can also install Kong via YUM; follow the instructions on the "Set Me Up"

--- a/app/install/debian.md
+++ b/app/install/debian.md
@@ -15,6 +15,8 @@ Start by downloading the corresponding package for your configuration:
 - [8 Jessie]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.jessie.all.deb)
 - [9 Stretch]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.stretch.all.deb)
 
+**Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
+
 ### APT Repositories
 
 You can also install Kong via APT; follow the instructions on the "Set Me Up"

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -154,4 +154,3 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
 4. **Deploy Kong**
 
     Continue from step 4 in the main set of instructions using the `kong_trial_*` YAML files. Note that you'll be able to access the Admin GUI at `<kong-admin-ip-address>:8002` or `https://<kong-ssl-admin-ip-address>:8445`.
-

--- a/app/install/kubernetes.md
+++ b/app/install/kubernetes.md
@@ -76,6 +76,8 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
     ```
 
 4. **Prepare database**
+    
+    **Kong Enterprise Edition trial users** should complete the steps in the **Additional steps for Kong EE Trial users** section below before proceeding.
 
     Using the `kong_migration_<postgres|cassandra>.yaml` file from this repo,
     run the migration job, jump to step 5 if Kong migrations are up–to–date:
@@ -121,3 +123,35 @@ Kong can easily be provisioned to Kubernetes cluster using the following steps:
 
     Quickly learn how to use Kong with the 
     [5-minute Quickstart](/docs/latest/getting-started/quickstart/).
+
+# Additional steps for Kong EE Trial users
+
+1. **Publishing an image to a container registry**
+
+    Because Kong Enterprise Edition images are not available on the public Docker container registry, you must publish them to a private repository for use with Kubernetes. While any private repository will work, this example uses the Google Cloud Platform Container Registry, which automatically integrates with the Google Cloud Platform examples in the other steps.
+    
+    In the steps below, replace `<image ID>` with ID associated with your loaded image in `docker images` output. Replace `<project ID>` with your [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+
+    ```bash
+    $ docker load -i /tmp/kong-docker-enterprise-edition.tar.gz
+    $ docker images
+    $ docker tag <image ID> gcr.io/<project ID>/kong-ee
+    $ gcloud docker -- push gcr.io/demo-cs-lab/kong-ee:latest
+    ```
+2. **Adding your license data**
+
+    Edit `kong_trial_postgres.yaml` and `kong_trial_migration_postgres.yaml` to replace `YOUR_LICENSE_HERE` with your license string. The end result should look like
+
+    ```yaml
+    - name: KONG_LICENSE_DATA
+    value: '{"license":{"signature":"alongstringofcharacters","payload":{"customer":"Test Company","license_creation_date":"2018-03-06","product_subscription":"Kong Only","admin_seats":"5","support_plan":"Premier","license_expiration_date":"2018-06-04","license_key":"anotherstringofcharacters"},"version":1}}'
+    ```
+
+3. **Using your image**
+
+    Edit `kong_trial_postgres.yaml` and `kong_trial_migration_postgres.yaml` and replace `image: kong` with `image: gcr.io/<project ID>/kong-ee`, using the same project ID as above.
+
+4. **Deploy Kong**
+
+    Continue from step 4 in the main set of instructions using the `kong_trial_*` YAML files. Note that you'll be able to access the Admin GUI at `<kong-admin-ip-address>:8002` or `https://<kong-ssl-admin-ip-address>:8445`.
+

--- a/app/install/redhat.md
+++ b/app/install/redhat.md
@@ -16,6 +16,8 @@ Start by downloading the corresponding package for your configuration:
 - [RHEL 6]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/6/kong-community-edition-{{site.data.kong_latest.version}}.el6.noarch.rpm)
 - [RHEL 7]({{ site.links.download }}/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-{{site.data.kong_latest.version}}.el7.noarch.rpm)
 
+**Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
+
 ### YUM Repositories
 
 You can also install Kong via YUM; follow the instructions on the "Set Me Up"

--- a/app/install/ubuntu.md
+++ b/app/install/ubuntu.md
@@ -16,6 +16,8 @@ Start by downloading the corresponding package for your configuration:
 - [16.04 Xenial]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.xenial.all.deb)
 - [17.04 Zesty]({{ site.links.download }}/kong-community-edition-deb/download_file?file_path=dists/kong-community-edition-{{site.data.kong_latest.version}}.zesty.all.deb)
 
+**Enterprise trial users** should download their package from their welcome email and save their license to `/etc/kong/license.json` after step 1.
+
 ### APT Repositories
 
 You can also install Kong via APT; follow the instructions on the "Set Me Up"


### PR DESCRIPTION
Minor updates to install instructions to direct trial customers to use their EE packages.

Kubernetes has additional instructions for uploading images.