### PR TITLE
docs(jwt) key_claim_name payload vs. header logic

### DIFF
--- a/app/plugins/jwt.md
+++ b/app/plugins/jwt.md
@@ -60,7 +60,7 @@ params:
       required: false
       default: "`iss`"
       description: |
-        The name of the claim in which the `key` identifying the secret **must** be passed.
+        The name of the claim in which the `key` identifying the secret **must** be passed. The JWT payload claims are first checked and if not found it then checks the JWT header claims.
     - name: secret_is_base64
       required: false
       default: "`false`"


### PR DESCRIPTION
### Summary

Update key_claim_name documentation to reference first checking the payload claims
and then checking the header claims

### Relevant Links

From Kong PR [#3313](https://github.com/Kong/kong/pull/3313)
