### PR TITLE
Google+Auth0 OIDC tutorials

### DIFF
--- a/app/_data/docs_nav_ee_0.31-x.yml
+++ b/app/_data/docs_nav_ee_0.31-x.yml
@@ -81,3 +81,7 @@
       url: /allowing-multiple-authentication-methods
     - text: PostgreSQL on RedHat
       url: /postgresql-redhat
+    - text: OpenID Connect with Google
+      url: /oidc-google
+    - text: OpenID Connect with Auth0
+      url: /oidc-auth0

--- a/app/docs/enterprise/0.31-x/oidc-auth0.md
+++ b/app/docs/enterprise/0.31-x/oidc-auth0.md
@@ -1,0 +1,41 @@
+---
+title: OpenID Connect with Auth0
+class: page-install-method
+---
+
+This guide covers an example OpenID Connect plugin configuration to authenticate headless services using Auth0's identity provider.
+
+# Auth0 IDP configuration
+
+This configuration will use a [client credentials grant](https://auth0.com/docs/api-auth/tutorials/client-credentials) as it is non-interactive, and because we expect clients to authenticate on behalf of themselves, not an end-user. To do so, you will need to [create an Auth0 API](https://auth0.com/docs/apis#how-to-configure-an-api-in-auth0) and a [non-interactive client](https://auth0.com/docs/clients).
+
+## API configuration
+
+When creating your API, you will need to specify an Identifier. Using the URL that your service makes requests to is generally appropriate, so this will typically be the hostname/path combination configured as a service or API in Kong.
+
+After creating your API, you will also need to add the `openid` scope at `https://manage.auth0.com/#/apis/<API ID>/scopes`.
+
+## Client configuration
+
+You will need to authorize your client to access your API. Auth0 will prompt you to do so after client creation if you select the API you created previously from the client's Quick Start menu. After toggling the client to Authorized, expand its authorization settings and enable the `openid` scope.
+
+# Kong configuration
+
+If you have not done so already, [create a service](https://getkong.org/docs/0.13.x/admin-api/#add-service) to protect. The `url` configuration should match the Identifier you used when configuring Auth0.
+
+Add an OpenID plugin configuration following the example below. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter](https://auth0.com/docs/api/authentication#client-credentials), which must be added as a custom argument:
+
+```bash
+$ curl -i -X POST http://kong:8001/kong-admin/services/<service name>/plugins --data name="openid-connect" \
+--data config.auth_methods="client_credentials" \
+--data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \
+--data config.token_post_args_names="audience" \
+--data config.token_post_args_values="https://example.com/"
+```
+
+# Downstream configuration
+
+The service accessing your resource will need to pass its credentials to Kong. It can do so via HTTP basic authentication, query string arguments, or parameters in the request body. Basic authentication is generally preferable, as credentials in a query string will be present in Kong's access logs (and possibly in other infrastructure's access logs, if you have HTTP-aware infrastracture in front of Kong) and credentials in request bodies are limited to request methods that expect
+client payloads.
+
+For basic authentication, use your client ID as the username and your client secret as the password. For the other methods, pass them as parameters named `client_id` and `client_secret`, respectively.

--- a/app/docs/enterprise/0.31-x/oidc-auth0.md
+++ b/app/docs/enterprise/0.31-x/oidc-auth0.md
@@ -35,7 +35,7 @@ $ curl -i -X POST http://kong:8001/kong-admin/services/<service name>/plugins --
 
 # Downstream configuration
 
-The service accessing your resource will need to pass its credentials to Kong. It can do so via HTTP basic authentication, query string arguments, or parameters in the request body. Basic authentication is generally preferable, as credentials in a query string will be present in Kong's access logs (and possibly in other infrastructure's access logs, if you have HTTP-aware infrastracture in front of Kong) and credentials in request bodies are limited to request methods that expect
+The service accessing your resource will need to pass its credentials to Kong. It can do so via HTTP basic authentication, query string arguments, or parameters in the request body. Basic authentication is generally preferable, as credentials in a query string will be present in Kong's access logs (and possibly in other infrastructure's access logs, if you have HTTP-aware infrastructure in front of Kong) and credentials in request bodies are limited to request methods that expect
 client payloads.
 
 For basic authentication, use your client ID as the username and your client secret as the password. For the other methods, pass them as parameters named `client_id` and `client_secret`, respectively.

--- a/app/docs/enterprise/0.31-x/oidc-google.md
+++ b/app/docs/enterprise/0.31-x/oidc-google.md
@@ -1,0 +1,58 @@
+---
+title: OpenID Connect with Google
+class: page-install-method
+---
+
+This guide covers an example OpenID Connect plugin configuration to authenticate browser clients using Google's identity provider.
+
+# Prerequisites
+
+Because OpenID Connect deals with user credentials, all transactions should take place over HTTPS. Although user passwords for third party identity providers are only submitted to those providers and not Kong, authentication tokens do grant access to a subset of user account data and protected APIs, and should be secured. As such, you should make Kong's proxy available via a fully-qualified domain name and [add a certificate](https://getkong.org/docs/0.13.x/admin-api/#add-certificate) for it.
+
+# Google IDP configuration
+
+Before configuring Kong, you'll need to set up a Google APIs project and create a credential set. Following [Google's instructions](https://developers.google.com/identity/protocols/OpenIDConnect), [create a new set of OAuth client ID credentials](https://console.developers.google.com/apis/credentials) with the Web application class. Add an authorized redirect URI for part of the API you wish to protect (more complex applications may redirect to a resource that sets additional
+application-specific state on the client, but for our purposes, any protected URI will work). Authorized JavaScript origins can be left blank.
+
+You can optionally customize the consent screen to inform clients who/what application is requesting authentication, but this is not required for testing. All steps after can be ignored, as Kong handles the server-side authentication request and token validation.
+
+# Kong configuration
+
+If you have not yet [added an API](https://getkong.org/docs/enterprise/latest/getting-started/adding-your-api/), go ahead and do so. Again, note that you should be able to secure this API with HTTPS, so if you are configuring a host, use a hostname you have a certificate for.
+
+## Basic plugin configuration
+
+The following will add OpenID Connect with authentication via Google to your API. Make sure to use the same redirect URI as configured earlier:
+
+```bash
+$ curl -i -X POST http://kong:8001/apis/example/plugins --data name="openid-connect" \
+  --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
+  --data config.client_id="YOUR_CLIENT_ID" \
+  --data config.client_secret="YOUR_CLIENT_SECRET" \
+  --data config.redirect_uri="https://example.com/api" \
+  --data config.scopes="openid,email"
+```
+
+Visiting a URL matched by that API in a browser will now redirect to Google's authentication site and return you to the redirect URI after authenticating. You'll note, however, that we did not configure anything to map authentication to consumers and that no consumer is associated with the subsequent request. Indeed, if you have configured other plugins that rely on consumer information, such as the ACL plugin, you will not have access. At present, the plugin configuration confirms that
+users have a Google account, but doesn't do anything with that information.
+
+Depending on your needs, it may not be necessary to associate clients with a consumer. You can, for example, configure the `domains` parameter to limit access to a internal users if you have a G Suite hosted domain, or configure `upstream_headers_claims` to send information about the user upstream (e.g. their email, a profile picture, their name, etc.) for use in your applications or for analytics.
+
+## Consumer mapping
+
+If you need to interact with other Kong plugins using consumer information, you must add configuration that maps account data received from the identity provider to a Kong consumer. For this example, we'll map the user's Google account email by setting a `custom_id` on their consumer, e.g.
+
+```bash
+$ curl -i -X POST http://kong:8001/consumers/ \
+  --data username="Yoda" \
+  --data custom_id="user@example.com"
+
+$ curl -i -X PATCH http://kong:8001/apis/example/plugins/<OIDC plugin ID> \
+  --data config.consumer_by="custom_id" \
+  --data config.consumer_claim="email"
+```
+
+Now, if a user logs into a Google account with the email `user@example.com`, Kong will apply configuration associated with the consumer `Yoda` to their requests. Note that while Google provides account emails, not all identity providers will. OpenID Connect does not have many required claims--the [only required user identity claim](http://openid.net/specs/openid-connect-core-1_0.html#IDToken) is `sub`, a unique subscriber ID. Many optional claims [are
+standardized](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims), however--if a provider returns an `email` claim, the contents will always be an email address.
+
+This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.


### PR DESCRIPTION
### Summary

Adds OIDC configuration tutorial for Google and Auth0

### Full changelog

* Added tutorial example OIDC+Google Identity Platform configuration for interactive clients (authorization code grant)
* Added tutorial example OIDC+Auth0 configuration for non-interactive clients (client credentials grant)

### Checklist:
- [X] Spellchecked my documentation
- [ ] Documentation N/A
- [X] Ready to be merged
