### PR TITLE
two times config.remove.headers

### DIFF
--- a/app/docs/enterprise/0.31-x/plugins/request-transformer.md
+++ b/app/docs/enterprise/0.31-x/plugins/request-transformer.md
@@ -34,7 +34,7 @@ You can also apply it for every API using the http://kong:8001/plugins/ endpoint
 |`config.remove.headers` <br>*optional* | List of header names. Unset the headers with the given name.
 |`config.remove.querystring`<br>*optional* | List of querystring names. Remove the querystring if it is present.
 |`config.remove.body`<br>*optional* | List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
-|`config.remove.headers` <br>*optional* | List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
+|`config.replace.headers` <br>*optional* | List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.
 |`config.replace.querystring`<br>*optional* | List of queryname:value pairs. If and only if the querystring name is already set, replace its old value with the new one. Ignored if the header is not already set.
 |`config.replace.uri`<br>*optional* | Updates the upstream request URI with given value. This value can only be used to update the path part of the uri, not the scheme, nor the hostname.
 |`config.replace.body`<br>*optional* | List of paramname:value pairs. If and only if content-type is one the following [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`] and the parameter is already present, replace its old value with the new one. Ignored if the parameter is not already present.


### PR DESCRIPTION
config.remove.headers should be config.replace.headers in second location

<!-- 
Thank your for making Kong better! #kongstrong

note: Check existing issues and pull-requests before submitting new ones, as a courtesy to the maintainers and making sure work isn't duplicated.
-->

**NOTE**: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/getkong.org/blob/master/CONTRIBUTING.md

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Edited docs to ...]
* [Added cool new feature ...]
* ...

### Issues resolved

Fix #XXX

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Spellchecked my documentation
- [ ] Documentation <!-- Add a new feature? Do you need to document it the README.md or otherwise? -->
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
