### PR TITLE
docs(fix) disambiguate advanced rate limting plugin

### DIFF
--- a/app/_data/docs_nav_ee_0.31-x.yml
+++ b/app/_data/docs_nav_ee_0.31-x.yml
@@ -26,13 +26,13 @@
 
 - title: APIs and Plugins
   items:
-    - text: Canary Release Plugin
+    - text: Canary Release
       url: /plugins/canary-release
-    - text: Rate Limiting Advanced Plugin
+    - text: Rate Limiting Advanced
       url: /plugins/rate-limiting
-    - text: Request Transformer Advanced Plugin
+    - text: Request Transformer Advanced
       url: /plugins/request-transformer
-    - text: OAuth2 Introspection Plugin
+    - text: OAuth2 Introspection
       url: /plugins/oauth2-introspection
     - text: HTTP Proxy Caching
       url: /plugins/http-proxy-caching

--- a/app/_data/docs_nav_ee_0.31-x.yml
+++ b/app/_data/docs_nav_ee_0.31-x.yml
@@ -28,9 +28,9 @@
   items:
     - text: Canary Release Plugin
       url: /plugins/canary-release
-    - text: Rate Limiting Plugin
+    - text: Rate Limiting Advanced Plugin
       url: /plugins/rate-limiting
-    - text: Request Transformer Plugin
+    - text: Request Transformer Advanced Plugin
       url: /plugins/request-transformer
     - text: OAuth2 Introspection Plugin
       url: /plugins/oauth2-introspection

--- a/app/docs/enterprise/0.31-x/plugins/rate-limiting.md
+++ b/app/docs/enterprise/0.31-x/plugins/rate-limiting.md
@@ -1,10 +1,16 @@
 ---
-title: Rate Limiting Plugin
+title: Rate Limiting Advanced Plugin
 ---
-# Rate Limiting Plugin
+# Rate Limiting Advanced Plugin
+
+Rate limiting functionality is available in two plugins - one is 
+[bundled with Kong Community Edition (CE)][/plugins/rate-limiting/],
+and the other is bundled with Kong Enterprise Edition (EE). This page documents the Kong EE version of 
+the Rate Limiting plugin, which has greater functionality and performance than the CE version. 
+
 ## Configuration
 
-Method 1: apply it on top of an API by executing the following request on your Kong server:
+Method 1: Apply it on top of an API by executing the following request on your Kong server:
 
 ```
 $ curl -i -X POST http://kong:8001/apis/{api}/plugins \
@@ -14,7 +20,7 @@ $ curl -i -X POST http://kong:8001/apis/{api}/plugins \
   --data config.window_size=60
 ```
 
-Method 2: apply it globally (on all APIs) by executing the following request on your Kong server:
+Method 2: Apply it globally (on all APIs) by executing the following request on your Kong server:
 
 ```
 $ curl -i -X POST http://kong:8001/plugins \
@@ -46,7 +52,9 @@ $ curl -i -X POST http://kong:8001/plugins \
 
 **Note:  Redis configuration values are ignored if the "cluster" strategy is used.**
 
-**Note: PostgreSQL 9.5+ is required when using the "cluster" strategy with "postgres" as the backing Kong cluster data store. This requirement varies from the PostgreSQL 9.4+ requirement as described in the <a href="/install/source">Kong Community Edition documentation</a>.**
+**Note: PostgreSQL 9.5+ is required when using the "cluster" strategy with "postgres" as the backing Kong 
+cluster data store. This requirement varies from the PostgreSQL 9.4+ requirement as described 
+in the <a href="/install/source">Kong Community Edition documentation</a>.**
 
 ---
 

--- a/app/docs/enterprise/0.31-x/plugins/rate-limiting.md
+++ b/app/docs/enterprise/0.31-x/plugins/rate-limiting.md
@@ -4,7 +4,7 @@ title: Rate Limiting Advanced Plugin
 # Rate Limiting Advanced Plugin
 
 Rate limiting functionality is available in two plugins - one is 
-[bundled with Kong Community Edition (CE)][/plugins/rate-limiting/],
+[bundled with Kong Community Edition (CE)](/plugins/rate-limiting/),
 and the other is bundled with Kong Enterprise Edition (EE). This page documents the Kong EE version of 
 the Rate Limiting plugin, which has greater functionality and performance than the CE version. 
 

--- a/app/docs/enterprise/0.31-x/plugins/request-transformer.md
+++ b/app/docs/enterprise/0.31-x/plugins/request-transformer.md
@@ -1,13 +1,19 @@
 ---
-title: Request Transformer Plugin
+title: Request Transformer Advanced Plugin
 ---
-# Request Transformer Plugin
+# Request Transformer Advanced Plugin
 
-Transform the request sent by a client on the fly on Kong, before hitting the upstream server.
+Transform the request sent by a client in Kong, before forwarding the request to the upstream service.
+
+Request transforming functionality is available in two plugins - one is 
+[bundled with Kong Community Edition (CE)](/plugins/request-transformer/),
+and the other is bundled with Kong Enterprise Edition (EE). This page documents the Kong EE version of 
+the Request Transformer plugin, which has greater functionality than the CE version. 
 
 ## Configuration
 
-Configuring the plugin is as simple as a single API call, you can configure and enable it for your [API](/docs/latest/admin-api/#api-object) 
+Configuring the plugin is as simple as a single API call, you can configure and enable it for your
+[API](/docs/latest/admin-api/#api-object) 
 (or [Consumer](/docs/latest/admin-api/#consumer-object)) by executing the following request on your Kong server:
 
 ```


### PR DESCRIPTION

### Summary

Make it more clear that Request Transformer and Rate Limiting are different in EE and CE

### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Spellchecked my documentation
- [ ] Documentation <!-- Add a new feature? Do you need to document it the README.md or otherwise? N/A -->
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
