### PR TITLE
fix(balancing) fix port omission

### DIFF
--- a/app/docs/0.13.x/loadbalancing.md
+++ b/app/docs/0.13.x/loadbalancing.md
@@ -62,7 +62,7 @@ Because the `weight` information is available, each entry will get its own
 weight in the load balancer and it will perform a weighted round-robin.
 
 Similarly, any given port information will be overridden by the port information from
-the DNS server. If a Service has an `host=myhost.com` attribute,
+the DNS server. If a Service has attributes `host=myhost.com` and `port=123`,
 and `myhost.com` resolves to an SRV record with `127.0.0.1:456`, then the request
 will be proxied to `http://127.0.0.1:456/somepath`, as port `123` will be
 overridden by `456`.


### PR DESCRIPTION
WIth the update to 0.13, routes and services, some info on ports was lost.

<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] [Commit message & atomicity](https://github.com/Kong/getkong.org/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
