### PR TITLE
docs(ce/app-docs) plugin tests should pass plugin name in helpers.start_kong

### DIFF
--- a/app/docs/0.13.x/plugin-development/tests.md
+++ b/app/docs/0.13.x/plugin-development/tests.md
@@ -46,7 +46,7 @@ for _, strategy in helpers.each_strategy() do
       })
 
       -- start Kong with your testing Kong configuration (defined in "spec.helpers")
-      assert(helpers.start_kong())
+      assert(helpers.start_kong( { custom_plugins = "my-plugin" }))
 
       admin_client = helpers.admin_client()
     end)


### PR DESCRIPTION
### Summary

* helpers.start_kong needs custom_plugin name in plugin tests

### Full changelog


### Issues resolved

https://github.com/Kong/kong/issues/3403

