### PR TITLE
docs(proxy) fix bootstrapped code in Kong API Loopback

### DIFF
--- a/app/docs/0.13.x/secure-admin-api.md
+++ b/app/docs/0.13.x/secure-admin-api.md
@@ -86,11 +86,12 @@ the `admin_listen` address as the Service's `url`. For example:
 
 $ curl -X POST http://localhost:8001/services \
   --data name=admin-api \
-  --data upstream_url=http://localhost:8001
+  --data host=localhost \
+  --data port=8001
 
-$ curl -X POST http://localhost:8001/services/admin-api/routes
-  --data uris=/admin-api
-
+$ curl -X POST http://localhost:8001/services/admin-api/routes \
+  --data paths[]=/admin-api
+  
 # we can now transparently reach the Admin API through the proxy server
 $ curl localhost:8000/admin-api/apis
 {


### PR DESCRIPTION
### Summary

When following the docs I couldn't get it right the first time, because the docs were saying to post params that version 0.13.0 no longer accept, like "upstream_url" in Services and "uris" in Routes.

I think this way will be more clear to new users understand.

### Full changelog

* [Edited docs to bootstrapping Kong API Loopback]

### Issues resolved



<!-- Have you done all of these things?  -->
### Checklist:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] [Commit message & atomicity](https://github.com/Kong/getkong.org/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [ ] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [X] Spellchecked my updates
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
