### PR TITLE
Document enabled flag for plugins

### DIFF
--- a/app/_layouts/plugin.html
+++ b/app/_layouts/plugin.html
@@ -103,6 +103,7 @@ Where `consumer_id` is the id of the Consumer we want to associate with this plu
     {% if page.params.route_id %}
       <tr><td><code>route_id</code></td><td></td><td>The id of the Route which this plugin will target.</td></tr>
     {% endif %}
+      <tr><td><code>enabled</code></td><td><code>true</code></td><td>Whether this plugin will be applied.</td></tr>
     {% if page.params.consumer_id %}
       <tr><td><code>consumer_id</code></td><td></td><td>The id of the Consumer which this plugin will target.</td></tr>
     {% endif %}

--- a/app/docs/0.10.x/admin-api.md
+++ b/app/docs/0.10.x/admin-api.md
@@ -30,6 +30,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 
 target_body: |
     Attributes | Description

--- a/app/docs/0.11.x/admin-api.md
+++ b/app/docs/0.11.x/admin-api.md
@@ -30,6 +30,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 
 target_body: |
     Attributes | Description

--- a/app/docs/0.12.x/admin-api.md
+++ b/app/docs/0.12.x/admin-api.md
@@ -30,6 +30,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 
 target_body: |
     Attributes | Description

--- a/app/docs/0.13.x/admin-api.md
+++ b/app/docs/0.13.x/admin-api.md
@@ -88,6 +88,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 
 target_body: |
     Attributes | Description

--- a/app/docs/0.3.x/admin-api.md
+++ b/app/docs/0.3.x/admin-api.md
@@ -22,6 +22,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `value.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.4.x/admin-api.md
+++ b/app/docs/0.4.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `value.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.5.x/admin-api.md
+++ b/app/docs/0.5.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.6.x/admin-api.md
+++ b/app/docs/0.6.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.7.x/admin-api.md
+++ b/app/docs/0.7.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.8.x/admin-api.md
+++ b/app/docs/0.8.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API

--- a/app/docs/0.9.x/admin-api.md
+++ b/app/docs/0.9.x/admin-api.md
@@ -23,6 +23,7 @@ plugin_configuration_body: |
     `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
     `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
     `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+    `enabled` | Whether the plugin is applied. Default: `true`.
 ---
 
 # Kong Admin API


### PR DESCRIPTION
### Summary

Add `enabled` to plugin pages and admin API documentation. 

### Issues resolved

Fix #691 

<!-- Have you done all of these things?  -->
### Checklist:
- [x] [Commit message & atomicity](https://github.com/Kong/getkong.org/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->