### PR TITLE
doc(api) Synch the certs admin API with Kong  branch

### DIFF
--- a/app/docs/0.14.x/admin-api.md
+++ b/app/docs/0.14.x/admin-api.md
@@ -1,0 +1,2591 @@
+---
+title: Admin API
+
+api_body: |
+    Attribute | Description
+    ---:| ---
+    `name`                        | The API name.
+    `hosts`<br>*semi-optional*    | A comma-separated list of domain names that point to your API. For example: `example.com`. At least one of `hosts`, `uris`, or `methods` should be specified.
+    `uris`<br>*semi-optional*     | A comma-separated list of URIs prefixes that point to your API. For example: `/my-path`. At least one of `hosts`, `uris`, or `methods` should be specified.
+    `methods`<br>*semi-optional*  | A comma-separated list of HTTP methods that point to your API. For example: `GET,POST`. At least one of `hosts`, `uris`, or `methods` should be specified.
+    `upstream_url`                | The base target URL that points to your API server. This URL will be used for proxying requests. For example: `https://example.com`.
+    `strip_uri`<br>*optional*     | When matching an API via one of the `uris` prefixes, strip that matching prefix from the upstream URI to be requested. Default: `true`.
+    `preserve_host`<br>*optional* | When matching an API via one of the `hosts` domain names, make sure the request `Host` header is forwarded to the upstream service. By default, this is `false`, and the upstream `Host` header will be extracted from the configured `upstream_url`.
+    `retries`<br>*optional*       | The number of retries to execute upon failure to proxy. The default is `5`.
+    `upstream_connect_timeout`<br>*optional* | The timeout in milliseconds for establishing a connection to your upstream service. Defaults to `60000`.
+    `upstream_send_timeout`<br>*optional*    | The timeout in milliseconds between two successive write operations for transmitting a request to your upstream service Defaults to `60000`.
+    `upstream_read_timeout`<br>*optional*    | The timeout in milliseconds between two successive read operations for transmitting a request to your upstream service Defaults to `60000`.
+    `https_only`<br>*optional*               | To be enabled if you wish to only serve an API through HTTPS, on the appropriate port (`8443` by default). Default: `false`.
+    `http_if_terminated`<br>*optional*       | Consider the `X-Forwarded-Proto` header when enforcing HTTPS only traffic. Default: `false`.
+
+service_body: |
+    Attributes | Description
+    ---:| ---
+    `name` <br>*optional*         | The Service name.
+    `protocol`                    | The protocol used to communicate with the upstream. It can be one of `http` (default) or `https`.
+    `host`                        | The host of the upstream server.
+    `port`                        | The upstream server port. Defaults to `80`.
+    `path`<br>*optional*          | The path to be used in requests to the upstream server. Empty by default.
+    `retries`<br>*optional*       | The number of retries to execute upon failure to proxy. The default is `5`.
+    `connect_timeout`<br>*optional* | The timeout in milliseconds for establishing a connection to the upstream server. Defaults to `60000`.
+    `write_timeout`<br>*optional*    | The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server. Defaults to `60000`.
+    `read_timeout`<br>*optional*    | The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server. Defaults to `60000`.
+    `url`<br>*shorthand-attribute*    | Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never "returns" the url).
+
+service_json: |
+    {
+        "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2",
+        "created_at": 1488869076800,
+        "updated_at": 1488869076800,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }
+
+route_body: |
+    Attributes | Description
+    ---:| ---
+    `protocols`<br>                | A list of the protocols this Route should allow. By default it is `["http", "https"]`, which means that the Route accepts both. When set to `["https"]`, HTTP requests are answered with a request to upgrade to HTTPS. With form-encoded, the notation is `protocols[]=http&protocols[]=https`. With JSON, use an Array.
+    `methods`<br>*semi-optional*   | A list of HTTP methods that match this Route. For example: `["GET", "POST"]`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `methods[]=GET&methods[]=OPTIONS`. With JSON, use an Array.
+    `hosts`<br>*semi-optional*     | A list of domain names that match this Route. For example: `example.com`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `hosts[]=foo.com&hosts[]=bar.com`. With JSON, use an Array.
+    `paths`<br>*semi-optional*     | A list of paths that match this Route. For example: `/my-path`. At least one of `hosts`, `paths`, or `methods` must be set. With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an Array.
+    `strip_path`<br>*optional*     | When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL. Defaults to `true`.
+    `preserve_host`<br>*optional*  | When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. By default set to `false`, and the upstream `Host` header will be that of the Service's `host`.
+    `service`                      | The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service_id>`. With JSON, use `"service":{"id":"<service_id>"}`.
+
+route_json: |
+    {
+        "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+        "created_at": 14888869056483,
+        "updated_at": 14888869056483,
+        "protocols": ["http", "https"],
+        "methods": null,
+        "hosts": ["example.com"],
+        "paths": null,
+        "regex_priority": 0,
+        "strip_path": true,
+        "preserve_host": false,
+        "service": {
+            "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+        }
+    }
+
+consumer_body: |
+    Attributes | Description
+    ---:| ---
+    `username`<br>**semi-optional** | The unique username of the consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>**semi-optional** | Field for storing an existing unique ID for the consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+
+plugin_configuration_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | The name of the Plugin that's going to be added. Currently the Plugin must be installed in every Kong instance separately.
+    `consumer_id`<br>*optional* | The unique identifier of the consumer that overrides the existing settings for this specific consumer on incoming requests.
+    `config.{property}` | The configuration properties for the Plugin which can be found on the plugins documentation page in the [Plugin Gallery](/plugins).
+
+target_body: |
+    Attributes | Description
+    ---:| ---
+    `target` | The target address (ip or hostname) and port. If omitted the `port` defaults to `8000`. If the hostname resolves to an SRV record, the `port` value will overridden by the value from the dns record.
+    `weight`<br>*optional* | The weight this target gets within the upstream loadbalancer (`0`-`1000`, defaults to `100`). If the hostname resolves to an SRV record, the `weight` value will overridden by the value from the dns record.
+
+upstream_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | This is a hostname, which must be equal to the `host` of a Service.
+    `slots`<br>*optional* | The number of slots in the loadbalancer algorithm (`10`-`65536`, defaults to `1000`).
+    `hash_on`<br>*optional* | What to use as hashing input: `none`, `consumer`, `ip`, or `header` (defaults to `none` resulting in a weighted-round-robin scheme).
+    `hash_fallback`<br>*optional* | What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no consumer identified): `none`, `consumer`, `ip`, or `header` (defaults to `none`).
+    `hash_on_header<br>*semi-optional* | The header name to take the value from as hash input (only required when `hash_on` is set to `header`).
+    `hash_fallback_header<br>*semi-optional* | The header name to take the value from as hash input (only required when `hash_fallback` is set to `header`).
+    `healthchecks.active.timeout`<br>*optional* | Socket timeout for active health checks (in seconds).
+    `healthchecks.active.concurrency`<br>*optional* | Number of targets to check concurrently in active health checks.
+    `healthchecks.active.http_path`<br>*optional* | Path to use in GET HTTP request to run as a probe on active health checks.
+    `healthchecks.active.healthy.interval`<br>*optional* | Interval between active health checks for healthy targets (in seconds). A value of zero indicates that active probes for healthy targets should not be performed.
+    `healthchecks.active.healthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks.
+    `healthchecks.active.healthy.successes`<br>*optional* | Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a target healthy.
+    `healthchecks.active.unhealthy.interval`<br>*optional* | Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed.
+    `healthchecks.active.unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks.
+    `healthchecks.active.unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in active probes to consider a target unhealthy.
+    `healthchecks.active.unhealthy.timeouts`<br>*optional* | Number of timeouts in active probes to consider a target unhealthy.
+    `healthchecks.active.unhealthy.http_failures`<br>*optional* | Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a target unhealthy.
+    `healthchecks.passive.healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.
+    `healthchecks.passive.healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in proxied traffic to consider a target unhealthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.timeouts`<br>*optional* | Number of timeouts in proxied traffic to consider a target unhealthy, as observed by passive health checks.
+    `healthchecks.passive.unhealthy.http_failures`<br>*optional* | Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a target unhealthy, as observed by passive health checks.
+
+certificate_body: |
+    Attributes | Description
+    ---:| ---
+    `cert` | PEM-encoded public certificate of the SSL key pair.
+    `key` | PEM-encoded private key of the SSL key pair.
+    `snis`<br>*optional* | One or more hostnames to associate with this certificate as an SNI. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience.
+
+snis_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | The SNI name to associate with the given certificate.
+    `ssl_certificate_id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname.
+
+---
+
+# Kong Admin API
+
+Kong comes with an **internal** RESTful Admin API for administration purposes.
+Requests to the Admin API can be sent to any node in the cluster, and Kong will
+keep the configuration consistent across all nodes.
+
+- `8001` is the default port on which the Admin API listens.
+- `8444` is the default port for HTTPS traffic to the Admin API.
+
+This API is designed for internal use and provides full control over Kong, so
+care should be taken when setting up Kong environments to avoid undue public
+exposure of this API. See [this document][secure-admin-api] for a discussion
+of methods to secure the Admin API.
+
+## Supported Content Types
+
+The Admin API accepts 2 content types on every endpoint:
+
+- **application/x-www-form-urlencoded**
+
+Simple enough for basic request bodies, you will probably use it most of the time. Note that when sending nested values, Kong expects nested objects to be referenced with dotted keys. Example:
+
+```
+config.limit=10&config.period=seconds
+```
+
+- **application/json**
+
+Handy for complex bodies (ex: complex plugin configuration), in that case simply send a JSON representation of the data you want to send. Example:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds"
+    }
+}
+```
+
+---
+
+## Information routes
+
+### Retrieve node information
+
+Retrieve generic details about a node.
+
+#### Endpoint
+
+<div class="endpoint get">/</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "hostname": "",
+    "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
+    "lua_version": "LuaJIT 2.1.0-beta3",
+    "plugins": {
+        "available_on_server": [
+            ...
+        ],
+        "enabled_in_cluster": [
+            ...
+        ]
+    },
+    "configuration" : {
+        ...
+    },
+    "tagline": "Welcome to Kong",
+    "version": "0.13.0"
+}
+```
+
+* `node_id`: A UUID representing the running Kong node. This UUID is randomly generated when Kong starts, so the node will have a different `node_id` each
+  time it is restarted.
+* `available_on_server`: Names of plugins that are installed on the node.
+* `enabled_in_cluster`: Names of plugins that are enabled/configured. That is, the plugins configurations currently in the datastore shared by all Kong nodes.
+
+---
+
+### Retrieve node status
+
+Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, and the status of the database connection.
+
+If you want to monitor the Kong process, since Kong is built on top of nginx, every existing nginx monitoring tool or agent can be used.
+
+#### Endpoint
+
+<div class="endpoint get">/status</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "server": {
+        "total_requests": 3,
+        "connections_active": 1,
+        "connections_accepted": 1,
+        "connections_handled": 1,
+        "connections_reading": 0,
+        "connections_writing": 1,
+        "connections_waiting": 0
+    },
+    "database": {
+        "reachable": true
+    }
+}
+```
+
+* `server`: Metrics about the nginx HTTP/S server.
+    * `total_requests`: The total number of client requests.
+    * `connections_active`: The current number of active client connections including Waiting connections.
+    * `connections_accepted`: The total number of accepted client connections.
+    * `connections_handled`: The total number of handled connections. Generally, the parameter value is the same as accepts unless some resource limits have been reached.
+    * `connections_reading`: The current number of connections where Kong is reading the request header.
+    * `connections_writing`: The current number of connections where nginx is writing the response back to the client.
+    * `connections_waiting`: The current number of idle client connections waiting for a request.
+* `database`: Metrics about the database.
+    * `reachable`: A boolean value reflecting the state of the database connection. Please note that this flag **does not** reflect the health of the database itself.
+
+---
+
+## Service Object
+
+Service entities, as the name implies, are abstractions of each of your own
+upstream services. Examples of Services would be a data transformation
+microservice, a billing API, etc.
+
+The main attribute of a Service is its URL (where Kong should proxy traffic
+to), which can be set as a single string or by specifying its `protocol`,
+`host`, `port` and `path` individually.
+
+Services are associated to Routes (a Service can have many Routes associated
+with it). Routes are entry-points in Kong and define rules to match client
+requests. Once a Route is matched, Kong proxies the request to its associated
+Service. See the [Proxy Reference][proxy-reference] for a detailed explanation
+of how Kong proxies traffic.
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Add Service
+
+#### Endpoint
+
+<div class="endpoint post">/services/</div>
+
+#### Request Body
+
+{{ page.service_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Retrieve Service
+
+#### Endpoints
+
+<div class="endpoint get">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+
+<div class="endpoint get">/routes/{route id}/service</div>
+
+Attributes | Description
+---:| ---
+`route id`<br>**required** | The unique identifier of a Route belonging to the Service to be retrieved.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+---
+
+### List Services
+
+#### Endpoint
+
+<div class="endpoint get">/services/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+`size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [{
+        "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2",
+        "created_at": 1488869076800,
+        "updated_at": 1488869076800,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }, {
+        "id": "8e13faaa-ee42-44ea-8421-255bc12316a1",
+        "created_at": 1488869077320,
+        "updated_at": 1488869077320,
+        "connect_timeout": 60000,
+        "protocol": "http",
+        "host": "example2.org",
+        "port": 80,
+        "path": "/api",
+        "name": "example-service2",
+        "retries": 5,
+        "read_timeout": 60000,
+        "write_timeout": 60000
+    }],
+    "next": "http://localhost:8001/services?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### Update Service
+
+#### Endpoints
+
+<div class="endpoint patch">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to update.
+
+<div class="endpoint patch">/routes/{route id}/service</div>
+
+Attributes | Description
+---:| ---
+`route id`<br>**required** | The `id` attribute of the Route whose Service is to be updated.
+
+#### Request Body
+
+{{ page.service_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Delete Service
+
+#### Endpoint
+
+<div class="endpoint delete">/services/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The `id` **or** the `name` attribute of the Service to delete.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Route Object
+
+The Route entities defines rules to match client requests. Each Route is
+associated with a Service, and a Service may have multiple Routes associated to
+it. Every request matching a given Route will be proxied to its associated
+Service.
+
+The combination of Routes and Services (and the separation of concerns between
+them) offers a powerful routing mechanism with which it is possible to define
+fine-grained entry-points in Kong leading to different upstream services of
+your infrastructure.
+
+```json
+{{ page.route_json }}
+```
+
+---
+
+### Add Route
+
+#### Endpoints
+
+<div class="endpoint post">/routes/</div>
+
+#### Request Body
+
+{{ page.route_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.route_json }}
+```
+
+### Retrieve Route
+
+#### Endpoints
+
+<div class="endpoint get">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to retrieve.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.route_json }}
+```
+
+---
+
+### List Routes
+
+#### Endpoints
+
+<div class="endpoint get">/routes</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+`size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [{
+      "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+      "created_at": 14888869056483,
+      "updated_at": 14888869056483,
+      "protocols": ["http", "https"],
+      "methods": null,
+      "hosts": ["example.com"],
+      "paths": null,
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }, {
+      "id": "8d9b862b-527c-4bf1-9786-bfbb728f6539",
+      "created_at": 14888869056435,
+      "updated_at": 14888869056435,
+      "protocols": ["http"],
+      "methods": ["GET"],
+      "hosts": ["example.com"],
+      "paths": ["/private"],
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }],
+    "next": "http://localhost:8001/services/foo/routes?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### List Routes associated to a Service
+
+#### Endpoints
+
+<div class="endpoint get">/services/{service name or id}/routes</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The `id` **or** the `name` attribute of the Service whose routes are to be Retrieved. When using this endpoint, only the Routes belonging to the specified Service will be listed.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [{
+      "id": "22108377-8f26-4c0e-bd9e-2962c1d6b0e6",
+      "created_at": 14888869056483,
+      "updated_at": 14888869056483,
+      "protocols": ["http", "https"],
+      "methods": null,
+      "hosts": ["example.com"],
+      "paths": null,
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }, {
+      "id": "8d9b862b-527c-4bf1-9786-bfbb728f6539",
+      "created_at": 14888869056435,
+      "updated_at": 14888869056435,
+      "protocols": ["http"],
+      "methods": ["GET"],
+      "hosts": ["example.com"],
+      "paths": ["/private"],
+      "regex_priority": 0,
+      "strip_path": true,
+      "preserve_host": false,
+      "service": {
+          "id": "4e13f54a-bbf1-47a8-8777-255fed7116f2"
+      }
+    }],
+    "next": "http://localhost:8001/services/foo/routes?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### Update Route
+
+#### Endpoint
+
+<div class="endpoint patch">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to update.
+
+#### Request Body
+
+{{ page.route_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+
+---
+
+### Delete Route
+
+#### Endpoint
+
+<div class="endpoint delete">/routes/{id}</div>
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The `id` attribute of the Route to delete.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## API Object
+
+<div class="alert alert-warning">
+  <p><strong>Note: The API entity was deprecated in Kong 0.13.0.</strong></p>
+  <p>It is strongly recommended to migrate your APIs to Routes and Services.</p>
+</div>
+
+The API object describes an API that's being exposed by Kong. Kong needs to know how to retrieve the
+API when a consumer is calling it from the Proxy port. Each API object must specify some combination
+of `hosts`, `uris`, and `methods`. Kong will proxy all requests to the API to the specified upstream URL.
+
+```json
+{
+    "created_at": 1488830759000,
+    "hosts": [
+        "example.org"
+    ],
+    "http_if_terminated": false,
+    "https_only": false,
+    "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+    "name": "example-api",
+    "preserve_host": false,
+    "retries": 5,
+    "strip_uri": true,
+    "upstream_connect_timeout": 60000,
+    "upstream_read_timeout": 60000,
+    "upstream_send_timeout": 60000,
+    "upstream_url": "http://httpbin.org"
+}
+```
+
+---
+
+### Add API
+
+#### Endpoint
+
+<div class="endpoint post">/apis/</div>
+
+#### Request Body
+
+{{ page.api_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "created_at": 1488830759000,
+    "hosts": [
+        "example.org"
+    ],
+    "http_if_terminated": false,
+    "https_only": false,
+    "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+    "name": "example-api",
+    "preserve_host": false,
+    "retries": 5,
+    "strip_uri": true,
+    "upstream_connect_timeout": 60000,
+    "upstream_read_timeout": 60000,
+    "upstream_send_timeout": 60000,
+    "upstream_url": "http://httpbin.org"
+}
+```
+
+---
+
+### Retrieve API
+
+#### Endpoint
+
+<div class="endpoint get">/apis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the API to retrieve
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "created_at": 1488830759000,
+    "hosts": [
+        "example.org"
+    ],
+    "http_if_terminated": false,
+    "https_only": false,
+    "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+    "name": "example-api",
+    "preserve_host": false,
+    "retries": 5,
+    "strip_uri": true,
+    "upstream_connect_timeout": 60000,
+    "upstream_read_timeout": 60000,
+    "upstream_send_timeout": 60000,
+    "upstream_url": "http://httpbin.org"
+}
+```
+
+---
+
+### List APIs
+
+#### Endpoint
+
+<div class="endpoint get">/apis/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the apis `id` field.
+`name`<br>*optional* | A filter on the list based on the apis `name` field.
+`upstream_url`<br>*optional* | A filter on the list based on the apis `upstream_url` field.
+`retries`<br>*optional* | A filter on the list based on the apis `retries` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [
+        {
+            "created_at": 1488830759000,
+            "hosts": [
+                "example.org"
+            ],
+            "http_if_terminated": false,
+            "https_only": false,
+            "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+            "name": "example-api",
+            "preserve_host": false,
+            "retries": 5,
+            "strip_uri": true,
+            "upstream_connect_timeout": 60000,
+            "upstream_read_timeout": 60000,
+            "upstream_send_timeout": 60000,
+            "upstream_url": "http://httpbin.org"
+        },
+        {
+            "created_at": 1488830708000,
+            "hosts": [
+                "api.com"
+            ],
+            "http_if_terminated": false,
+            "https_only": false,
+            "id": "0924978e-eb19-44a0-9adc-55f20db2f04d",
+            "name": "my-api",
+            "preserve_host": false,
+            "retries": 10,
+            "strip_uri": true,
+            "upstream_connect_timeout": 1000,
+            "upstream_read_timeout": 1000,
+            "upstream_send_timeout": 1000,
+            "upstream_url": "http://my-api.com"
+        }
+    ],
+    "next": "http://localhost:8001/apis?size=2&offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+---
+
+### Update API
+
+#### Endpoint
+
+<div class="endpoint patch">/apis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the API to update
+
+#### Request Body
+
+{{ page.api_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "created_at": 1488830759000,
+    "hosts": [
+        "updated-example.org"
+    ],
+    "http_if_terminated": false,
+    "https_only": false,
+    "id": "6378122c-a0a1-438d-a5c6-efabae9fb969",
+    "name": "my-updated-api",
+    "preserve_host": false,
+    "retries": 5,
+    "strip_uri": true,
+    "upstream_connect_timeout": 60000,
+    "upstream_read_timeout": 60000,
+    "upstream_send_timeout": 60000,
+    "upstream_url": "http://httpbin.org"
+}
+```
+
+---
+
+### Update Or Create API
+
+#### Endpoint
+
+<div class="endpoint put">/apis/</div>
+
+#### Request Body
+
+{{ page.api_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` for APIs), the entity will be
+created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete API
+
+#### Endpoint
+
+<div class="endpoint delete">/apis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the API to delete
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+---
+
+## Consumer Object
+
+The Consumer object represents a consumer - or a user - of a Service. You can either rely on Kong as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong and your existing primary datastore.
+
+```json
+{
+    "custom_id": "abc123"
+}
+```
+
+---
+
+### Create Consumer
+
+#### Endpoint
+
+<div class="endpoint post">/consumers/</div>
+
+#### Request Form Parameters
+
+{{ page.consumer_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Retrieve Consumer
+
+#### Endpoint
+
+<div class="endpoint get">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the username of the consumer to retrieve
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List Consumers
+
+#### Endpoint
+
+<div class="endpoint get">/consumers/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the consumer `id` field.
+`custom_id`<br>*optional* | A filter on the list based on the consumer `custom_id` field.
+`username`<br>*optional* | A filter on the list based on the consumer `username` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [
+        {
+            "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+            "custom_id": "abc123",
+            "created_at": 1422386534
+        },
+        {
+            "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+            "custom_id": "def345",
+            "created_at": 1422386585
+        }
+    ],
+    "next": "http://localhost:8001/consumers/?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Consumer
+
+#### Endpoint
+
+<div class="endpoint patch">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the username of the consumer to update
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "custom_id": "updated_abc123",
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update Or Create Consumer
+
+#### Endpoint
+
+<div class="endpoint put">/consumers/</div>
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` for Consumers), the entity will be
+created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Consumer
+
+#### Endpoint
+
+<div class="endpoint delete">/consumers/{username or id}</div>
+
+Attributes | Description
+---:| ---
+`username or id`<br>**required** | The unique identifier **or** the name of the consumer to delete
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Plugin Object
+
+A Plugin entity represents a plugin configuration that will be executed during
+the HTTP request/response lifecycle. It is how you can add functionalities
+to Services that run behind Kong, like Authentication or Rate Limiting for
+example. You can find more information about how to install and what values
+each plugin takes by visiting the [Plugins Gallery](/plugins).
+
+When adding a Plugin Configuration to a Service, every request made by a client to
+that Service will run said Plugin. If a Plugin needs to be tuned to different
+values for some specific Consumers, you can do so by specifying the
+`consumer_id` value:
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+See the [Precedence](#precedence) section below for more details.
+
+#### Precedence
+
+A plugin will always be run once and only once per request. But the
+configuration with which it will run depends on the entities it has been
+configured for.
+
+Plugins can be configured for various entities, combination of entities, or
+even globally. This is useful, for example, when you wish to configure a plugin
+a certain way for most requests, but make _authenticated requests_ behave
+slightly differently.
+
+Therefore, there exists an order of precedence for running a plugin when it has
+been applied to different entities with different configurations. The rule of
+thumb is: the more specific a plugin is with regards to how many entities it
+has been configured on, the higher its priority.
+
+The complete order of precedence when a plugin has been configured multiple
+times is:
+
+1. Plugins configured on a combination of: a Route, a Service, and a Consumer.
+   _(Consumer means the request must be authenticated)._
+2. Plugins configured on a combination of a Route and a Consumer.
+   _(Consumer means the request must be authenticated)._
+3. Plugins configured on a combination of a Service and a Consumer.
+   _(Consumer means the request must be authenticated)._
+4. Plugins configured on a combination of a Route and a Service.
+5. Plugins configured on a Consumer.
+   _(Consumer means the request must be authenticated)._
+6. Plugins configured on a Route.
+7. Plugins configured on a Service.
+8. Plugins configured to run globally.
+
+**Example**: if the `rate-limiting` plugin is applied twice (with different
+configurations): for a Service (Plugin config A), and for a Consumer (Plugin
+config B), then requests authenticating this Consumer will run Plugin config B
+and ignore A. However, requests that do not authenticate this Consumer will
+fallback to running Plugin config A.
+
+---
+
+### Add Plugin
+
+You can add a plugin in four different ways:
+
+* For every Service/Route and Consumer. Don't set `consumer_id` and set `service_id` or `route_id`.
+* For every Service/Route and a specific Consumer. Only set `consumer_id`.
+* For every Consumer and a specific Service. Only set `service_id` (warning: some plugins only allow setting their `route_id`)
+* For every Consumer and a specific Route. Only set `route_id` (warning: some plugins only allow setting their `service_id`)
+* For a specific Service/Route and Consumer. Set both `service_id`/`route_id` and `consumer_id`.
+
+Note that not all plugins allow to specify `consumer_id`. Check the plugin documentation.
+
+#### Endpoint
+
+<div class="endpoint post">/plugins/</div>
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+## Retrieve Plugin
+
+<div class="endpoint get">/plugins/{id}</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>**required** | The unique identifier of the plugin to retrieve
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+### List All Plugins
+
+#### Endpoint
+
+<div class="endpoint get">/plugins/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the `id` field.
+`name`<br>*optional* | A filter on the list based on the `name` field.
+`service_id`<br>*optional* | A filter on the list based on the `service_id` field.
+`route_id`<br>*optional* | A filter on the list based on the `route_id` field.
+`consumer_id`<br>*optional* | A filter on the list based on the `consumer_id` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 10,
+    "data": [
+      {
+          "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+          "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "name": "rate-limiting",
+          "config": {
+              "minute": 20,
+              "hour": 500
+          },
+          "enabled": true,
+          "created_at": 1422386534
+      },
+      {
+          "id": "3f924084-1adb-40a5-c042-63b19db421a2",
+          "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+          "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+          "name": "rate-limiting",
+          "config": {
+              "minute": 300,
+              "hour": 20000
+          },
+          "enabled": true,
+          "created_at": 1422386585
+      }
+    ],
+    "next": "http://localhost:8001/plugins?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+}
+```
+
+---
+
+### Update Plugin
+
+#### Endpoint
+
+<div class="endpoint patch">/plugins/{plugin id}</div>
+
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to update
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "service_id": "5fd1z584-1adb-40a5-c042-63b19db49x21",
+    "consumer_id": "a3dX2dh2-1adb-40a5-c042-63b19dbx83hF4",
+    "name": "rate-limiting",
+    "config": {
+        "minute": 20,
+        "hour": 500
+    },
+    "enabled": true,
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update or Add Plugin
+
+#### Endpoint
+
+<div class="endpoint put">/plugins/</div>
+
+#### Request Body
+
+{{ page.plugin_configuration_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` and `name` for Plugins), the entity
+will be created with the given payload. If the request payload **does** contain
+an entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Plugin
+
+#### Endpoint
+
+<div class="endpoint delete">/plugins/{plugin id}</div>
+
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the plugin configuration to delete
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Retrieve Enabled Plugins
+
+Retrieve a list of all installed plugins on the Kong node.
+
+#### Endpoint
+
+<div class="endpoint get">/plugins/enabled</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "enabled_plugins": [
+        "jwt",
+        "acl",
+        "cors",
+        "oauth2",
+        "tcp-log",
+        "udp-log",
+        "file-log",
+        "http-log",
+        "key-auth",
+        "hmac-auth",
+        "basic-auth",
+        "ip-restriction",
+        "request-transformer",
+        "response-transformer",
+        "request-size-limiting",
+        "rate-limiting",
+        "response-ratelimiting",
+        "aws-lambda",
+        "bot-detection",
+        "correlation-id",
+        "datadog",
+        "galileo",
+        "ldap-auth",
+        "loggly",
+        "runscope",
+        "statsd",
+        "syslog"
+    ]
+}
+```
+
+---
+
+### Retrieve Plugin Schema
+
+Retrieve the schema of a plugin's configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong's plugin system.
+
+<div class="endpoint get">/plugins/schema/{plugin name}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "fields": {
+        "hide_credentials": {
+            "default": false,
+            "type": "boolean"
+        },
+        "key_names": {
+            "default": "function",
+            "required": true,
+            "type": "array"
+        }
+    }
+}
+```
+
+---
+
+## Certificate Object
+
+A certificate object represents a public certificate/private key pair for an SSL
+certificate. These objects are used by Kong to handle SSL/TLS termination for
+encrypted requests. Certificates are optionally associated with SNI objects to
+tie a cert/key pair to one or more hostnames.
+
+```json
+{
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----..."
+}
+```
+
+---
+
+### Add Certificate
+
+#### Endpoint
+
+<div class="endpoint post">/certificates/</div>
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve Certificate
+
+#### Endpoint
+
+<div class="endpoint get">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+---
+
+### List Certificates
+
+#### Endpoint
+
+<div class="endpoint get">/certificates/</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+            "cert": "-----BEGIN CERTIFICATE-----...",
+            "key": "-----BEGIN RSA PRIVATE KEY-----...",
+            "snis": [
+                "example.com"
+            ],
+            "created_at": 1485521710265
+        },
+        {
+            "id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
+            "cert": "-----BEGIN CERTIFICATE-----...",
+            "key": "-----BEGIN RSA PRIVATE KEY-----...",
+            "snis": [
+                "example.org"
+            ],
+            "created_at": 1485522651185
+        }
+    ]
+}
+```
+---
+
+### Update Certificate
+
+<div class="endpoint patch">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "cert": "-----BEGIN CERTIFICATE-----...",
+    "key": "-----BEGIN RSA PRIVATE KEY-----...",
+    "snis": [
+        "example.com"
+    ],
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Update or Create Certificate
+
+#### Endpoint
+
+<div class="endpoint put">/certificates/</div>
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` for Certificates), the entity will
+be created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete Certificate
+
+<div class="endpoint delete">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`sni or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## SNI Objects
+
+An SNI object represents a many-to-one mapping of hostnames to a certificate.
+That is, a certificate object can have many hostnames associated with it; when
+Kong receives an SSL request, it uses the SNI field in the Client Hello to
+lookup the certificate object based on the SNI associated with the certificate.
+
+```json
+{
+    "name": "example.com",
+    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+}
+```
+
+---
+
+### Add SNI
+
+#### Endpoint
+
+<div class="endpoint post">/snis/</div>
+
+#### Request Body
+
+{{ page.snis_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "name": "example.com",
+    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve SNI
+
+#### Endpoint
+
+<div class="endpoint get">/snis/{name}</div>
+
+Attributes | Description
+---:| ---
+`name`<br>**required** | The name of the SNI object.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "name": "example.com",
+    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "created_at": 1485521710265
+}
+```
+
+### List SNIs
+
+#### Endpoint
+
+<div class="endpoint get">/snis/</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "name": "example.com",
+            "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+            "created_at": 1485521710265
+        },
+        {
+            "name": "example.org",
+            "ssl_certificate_id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
+            "created_at": 1485521710265
+        }
+    ]
+}
+```
+
+---
+
+### Update SNI
+
+<div class="endpoint patch">/snis/{name}</div>
+
+Attributes | Description
+---:| ---
+`name`<br>**required** | The name of the SNI object.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "name": "example.com",
+    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Update or Create SNI
+
+#### Endpoint
+
+<div class="endpoint put">/snis/</div>
+
+#### Request Body
+
+{{ page.snis_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`name` for SNIs), the entity will be
+created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete SNI
+
+<div class="endpoint delete">/snis/{name}</div>
+
+Attributes | Description
+---:| ---
+`name`<br>**required** | The name of the SNI object.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+## Upstream Objects
+
+The upstream object represents a virtual hostname and can be used to loadbalance
+incoming requests over multiple services (targets). So for example an upstream
+named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`.
+Requests for this Service would be proxied to the targets defined within the upstream.
+
+An upstream also includes a [health checker][healthchecks], which is able to
+enable and disable targets based on their ability or inability to serve
+requests. The configuration for the health checker is stored in the upstream
+object, and applies to all of its targets.
+
+```json
+{
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10
+}
+```
+
+---
+
+### Add upstream
+
+#### Endpoint
+
+<div class="endpoint post">/upstreams/</div>
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10,
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### Retrieve upstream
+
+#### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to retrieve
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10,
+    "created_at": 1485521710265
+}
+```
+
+---
+
+### List upstreams
+
+#### Endpoint
+
+<div class="endpoint get">/upstreams/</div>
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the upstream `id` field.
+`name`<br>*optional* | A filter on the list based on the upstream `name` field.
+`hash_on`<br>*optional* | A filter on the list based on the upstream `hash_on` field.
+`hash_fallback`<br>*optional* | A filter on the list based on the upstream `hash_fallback` field.
+`hash_on_header`<br>*optional* | A filter on the list based on the upstream `hash_on_header` field.
+`hash_fallback_header`<br>*optional* | A filter on the list based on the upstream `hash_fallback_header` field.
+`slots`<br>*optional* | A filter on the list based on the upstream `slots` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 3,
+    "data": [
+        {
+            "created_at": 1485521710265,
+            "id": "13611da7-703f-44f8-b790-fc1e7bf51b3e",
+            "name": "service.v1.xyz",
+            "hash_on": "none",
+            "hash_fallback": "none",
+            "healthchecks": {
+                "active": {
+                    "concurrency": 10,
+                    "healthy": {
+                        "http_statuses": [ 200, 302 ],
+                        "interval": 0,
+                        "successes": 0
+                    },
+                    "http_path": "/",
+                    "timeout": 1,
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [ 429, 404, 500, 501,
+                                           502, 503, 504, 505 ],
+                        "interval": 0,
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                },
+                "passive": {
+                    "healthy": {
+                        "http_statuses": [ 200, 201, 202, 203,
+                                           204, 205, 206, 207,
+                                           208, 226, 300, 301,
+                                           302, 303, 304, 305,
+                                           306, 307, 308 ],
+                        "successes": 0
+                    },
+                    "unhealthy": {
+                        "http_failures": 0,
+                        "http_statuses": [ 429, 500, 503 ],
+                        "tcp_failures": 0,
+                        "timeouts": 0
+                    }
+                }
+            },
+            "slots": 10
+        },
+        {
+            "created_at": 1485522651185,
+            "id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "name": "service.v2.xyz",
+            "hash_on": "none",
+            "hash_fallback": "none",
+            "healthchecks": {
+                "active": {
+                    "concurrency": 10,
+                    "healthy": {
+                        "http_statuses": [ 200, 302 ],
+                        "interval": 5,
+                        "successes": 2
+                    },
+                    "http_path": "/health_status",
+                    "timeout": 1,
+                    "unhealthy": {
+                        "http_failures": 5,
+                        "http_statuses": [ 429, 404, 500, 501,
+                                           502, 503, 504, 505 ],
+                        "interval": 5,
+                        "tcp_failures": 2,
+                        "timeouts": 3
+                    }
+                },
+                "passive": {
+                    "healthy": {
+                        "http_statuses": [ 200, 201, 202, 203,
+                                           204, 205, 206, 207,
+                                           208, 226, 300, 301,
+                                           302, 303, 304, 305,
+                                           306, 307, 308 ],
+                        "successes": 5
+                    },
+                    "unhealthy": {
+                        "http_failures": 5,
+                        "http_statuses": [ 429, 500, 503 ],
+                        "tcp_failures": 2,
+                        "timeouts": 7
+                    }
+                }
+            },
+            "slots": 10
+        }
+    ],
+    "next": "http://localhost:8001/upstreams?size=2&offset=Mg%3D%3D",
+    "offset": "Mg=="
+}
+```
+
+---
+
+### Update upstream
+
+#### Endpoint
+
+<div class="endpoint patch">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to update
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "id": "4d924084-1adb-40a5-c042-63b19db421d1",
+    "name": "service.v1.xyz",
+    "hash_on": "none",
+    "hash_fallback": "none",
+    "slots": 10,
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "created_at": 1422386534
+}
+```
+
+---
+
+### Update Or create Upstream
+
+#### Endpoint
+
+<div class="endpoint put">/upstreams/</div>
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+The behavior of `PUT` endpoints is the following: if the request payload **does
+not** contain an entity's primary key (`id` for Upstreams), the entity will be
+created with the given payload. If the request payload **does** contain an
+entity's primary key, the payload will "replace" the entity specified by the
+given primary key. If the primary key is **not** that of an existing entity, `404
+NOT FOUND` will be returned.
+
+#### Response
+
+```
+HTTP 201 Created or HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+---
+
+### Delete upstream
+
+#### Endpoint
+
+<div class="endpoint delete">/upstreams/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to delete
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Show Upstream health for node
+
+Displays the health status for all Targets of a given Upstream, according to
+the perspective of a specific Kong node. Note that, being node-specific
+information, making this same request to different nodes of the Kong cluster
+may produce different results. For example, one specific node of the Kong
+cluster may be experiencing network issues, causing it to fail to connect to
+some Targets: these Targets will be marked as unhealthy by that node
+(directing traffic from this node to other Targets that it can successfully
+reach), but healthy to all others Kong nodes (which have no problems using that
+Target).
+
+The `data` field of the response contains an array of Target objects.
+The health for each Target is returned in its `health` field:
+
+* If a Target fails to be activated in the ring balancer due to DNS issues,
+  its status displays as `DNS_ERROR`.
+* When [health checks][healthchecks] are not enabled in the Upstream
+  configuration, the health status for active Targets is displayed as
+  `HEALTHCHECKS_OFF`.
+* When health checks are enabled and the Target is determined to be healthy,
+  either automatically or [manually](#set-target-as-healthy),
+  its status is displayed as `HEALTHY`. This means that this Target is
+  currently included in this Upstream's load balancer ring.
+* When a Target has been disabled by either active or passive health checks
+  (circuit breakers) or [manually](#set-target-as-unhealthy),
+  its status is displayed as `UNHEALTHY`. The load balancer is not directing
+  any traffic to this Target via this Upstream.
+
+### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}/health/</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "node_id": "cbb297c0-14a9-46bc-ad91-1d0ef9b42df9",
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "health": "HEALTHY",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "health": "UNHEALTHY",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+## Target Object
+
+A target is an ip address/hostname with a port that identifies an instance of a backend
+service. Every upstream can have many targets, and the targets can be
+dynamically added. Changes are effectuated on the fly.
+
+Because the upstream maintains a history of target changes, the targets cannot
+be deleted or modified. To disable a target, post a new one with `weight=0`;
+alternatively, use the `DELETE` convenience method to accomplish the same.
+
+The current target object definition is the one with the latest `created_at`.
+
+```json
+{
+    "target": "1.2.3.4:80",
+    "weight": 15,
+    "upstream_id": "ee3310c1-6789-40ac-9386-f79c0cb58432"
+}
+```
+
+---
+
+### Add target
+
+#### Endpoint
+
+<div class="endpoint post">/upstreams/{name or id}/targets</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream to which to add the target
+
+#### Request Body
+
+{{ page.target_body }}
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": "4661f55e-95c2-4011-8fd6-c5c56df1c9db",
+    "target": "1.2.3.4:80",
+    "weight": 15,
+    "upstream_id": "ee3310c1-6789-40ac-9386-f79c0cb58432",
+    "created_at": 1485523507446
+}
+```
+
+---
+
+### List targets
+
+Lists all targets currently active on the upstream's load balancing wheel.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> The behavior of this endpoint changed in the 0.12.0
+  release from returning all targets belonging to an upstream, to only
+  currently active ones. The endpoint returning the entire history of targets
+  was moved to [List all targets](#list-all-targets).
+</div>
+
+#### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}/targets</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`id`<br>*optional* | A filter on the list based on the target `id` field.
+`target`<br>*optional* | A filter on the list based on the target `target` field.
+`weight`<br>*optional* | A filter on the list based on the target `weight` field.
+`size`<br>*optional, default is __100__* | A limit on the number of objects to be returned.
+`offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 30,
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524897232,
+            "id": "9b96f13d-65af-4f30-bbe9-b367121dd26b",
+            "target": "127.0.0.1:20001",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 0
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+### List all targets
+
+Lists all targets of the upstream. Multiple target objects for the same
+target may be returned, showing the history of changes for a specific target.
+The target object with the latest `created_at` is the current definition.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This endpoint is only available with Kong 0.12.0+
+</div>
+
+### Endpoint
+
+<div class="endpoint get">/upstreams/{name or id}/targets/all/</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+---
+
+### Delete target
+
+Disable a target in the load balancer. Under the hood, this method creates
+a new entry for the given target definition with a `weight` of 0.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This endpoint is only available with Kong 0.10.1+
+</div>
+
+#### Endpoint
+
+<div class="endpoint delete">/upstreams/{upstream name or id}/targets/{target or id}</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
+`target or id`<br>**required** | The host/port combination element of the target to remove, or the `id` of an existing target entry.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Set target as healthy
+
+Set the current health status of a target in the load balancer to "healthy"
+in the entire Kong cluster.
+
+This endpoint can be used to manually re-enable a target that was previously
+disabled by the upstream's [health checker][healthchecks]. Upstreams only
+forward requests to healthy nodes, so this call tells Kong to start using this
+target again.
+
+This resets the health counters of the health checkers running in all workers
+of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+status is propagated to the whole Kong cluster.
+
+#### Endpoint
+
+<div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### Set target as unhealthy
+
+Set the current health status of a target in the load balancer to "unhealthy"
+in the entire Kong cluster.
+
+This endpoint can be used to manually disable a target and have it stop
+responding to requests. Upstreams only forward requests to healthy nodes, so
+this call tells Kong to start skipping this target in the ring-balancer
+algorithm.
+
+This call resets the health counters of the health checkers running in all
+workers of the Kong node, and broadcasts a cluster-wide message so that the
+"unhealthy" status is propagated to the whole Kong cluster.
+
+[Active health checks][active] continue to execute for unhealthy
+targets. Note that if active health checks are enabled and the probe detects
+that the target is actually healthy, it will automatically re-enable it again.
+To permanently remove a target from the ring-balancer, you should [delete a
+target](#delete-target) instead.
+
+#### Endpoint
+
+<div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+[clustering]: /docs/{{page.kong_version}}/clustering
+[cli]: /docs/{{page.kong_version}}/cli
+[active]: /docs/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+[healthchecks]: /docs/{{page.kong_version}}/health-checks-circuit-breakers
+[secure-admin-api]: /docs/{{page.kong_version}}/secure-admin-api
+[proxy-reference]: /docs/{{page.kong_version}}/proxy

--- a/app/docs/0.14.x/admin-api.md
+++ b/app/docs/0.14.x/admin-api.md
@@ -127,13 +127,13 @@ certificate_body: |
     ---:| ---
     `cert` | PEM-encoded public certificate of the SSL key pair.
     `key` | PEM-encoded private key of the SSL key pair.
-    `snis`<br>*optional* | One or more hostnames to associate with this certificate as an SNI. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience.
+    `snis`<br>*optional* | An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience.
 
 snis_body: |
     Attributes | Description
     ---:| ---
     `name` | The SNI name to associate with the given certificate.
-    `ssl_certificate_id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname.
+    `certificate_id` | The `id` (a UUID) of the certificate with which to associate the SNI hostname.
 
 ---
 
@@ -1620,18 +1620,32 @@ HTTP 200 OK
 
 #### Endpoint
 
-<div class="endpoint put">/certificates/</div>
+<div class="endpoint put">/certificates/{sni or id}</div>
+
+Attributes | Description
+---:| ---
+`SNI or id`<br>**required** | The unique identifier **or** an SNI name associated with this certificate.
 
 #### Request Body
 
 {{ page.certificate_body }}
 
-The behavior of `PUT` endpoints is the following: if the request payload **does
-not** contain an entity's primary key (`id` for Certificates), the entity will
-be created with the given payload. If the request payload **does** contain an
-entity's primary key, the payload will "replace" the entity specified by the
-given primary key. If the primary key is **not** that of an existing entity, `404
-NOT FOUND` will be returned.
+Inserts (or replaces) the Certificate under the requested resource with the definition
+specified in the body. The Certificate will be identified by the `SNI or id` attribute.
+
+If the Certificate for the provided id exists, or an SNI with the provided name exists,
+this request will update said certificate using the request body. If the body includes an `snis`
+pseudo-attribute, then the list of snis associated with the certificate will also be updated.
+
+If the certificate for the provided id does not exist, a new certificate will be created
+using the request body with the provided `id`. If the request body includes an `snis` pseudo-attribute,
+then it will also create a list SNIs associated to the new certificate.
+
+If no SNI with the provided sni name can be found, then a new certificate will be created using the
+request body. If no `id` is included on the body, the newly-created certificate will have a random `id`.
+
+If present, the `snis` pseudo-attribute will be used to create other SNIs associated to the certificate.
+Note that providing an `snis` pseudo-attribute which does not include the provided SNI name is not allowed.
 
 #### Response
 
@@ -1668,8 +1682,10 @@ lookup the certificate object based on the SNI associated with the certificate.
 
 ```json
 {
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68"
+    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "created_at": 1485521710265
 }
 ```
 
@@ -1693,8 +1709,9 @@ HTTP 201 Created
 
 ```json
 {
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
     "created_at": 1485521710265
 }
 ```
@@ -1705,11 +1722,11 @@ HTTP 201 Created
 
 #### Endpoint
 
-<div class="endpoint get">/snis/{name}</div>
+<div class="endpoint get">/snis/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`name`<br>**required** | The name of the SNI object.
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
 
 #### Response
 
@@ -1719,8 +1736,9 @@ HTTP 200 OK
 
 ```json
 {
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
     "created_at": 1485521710265
 }
 ```
@@ -1742,13 +1760,15 @@ HTTP 200 OK
     "total": 2,
     "data": [
         {
+            "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
             "name": "example.com",
-            "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+            "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
             "created_at": 1485521710265
         },
         {
+            "id": "88c03fcd-9a48-4937-a976-0abd0eb6b60a",
             "name": "example.org",
-            "ssl_certificate_id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
+            "certificate_id": "6b5b6f71-c0b3-426d-8f3b-8de2c67c816b",
             "created_at": 1485521710265
         }
     ]
@@ -1759,11 +1779,11 @@ HTTP 200 OK
 
 ### Update SNI
 
-<div class="endpoint patch">/snis/{name}</div>
+<div class="endpoint patch">/snis/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`name`<br>**required** | The name of the SNI object.
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
 
 #### Response
 
@@ -1773,8 +1793,9 @@ HTTP 200 OK
 
 ```json
 {
+    "id": "daa105c8-9208-49e7-83fa-2fc0da28c6bd",
     "name": "example.com",
-    "ssl_certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
+    "certificate_id": "21b69eab-09d9-40f9-a55e-c4ee47fada68",
     "created_at": 1485521710265
 }
 ```
@@ -1785,18 +1806,27 @@ HTTP 200 OK
 
 #### Endpoint
 
-<div class="endpoint put">/snis/</div>
+<div class="endpoint put">/snis/{name or id}</div>
+
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
 
 #### Request Body
 
 {{ page.snis_body }}
 
-The behavior of `PUT` endpoints is the following: if the request payload **does
-not** contain an entity's primary key (`name` for SNIs), the entity will be
-created with the given payload. If the request payload **does** contain an
-entity's primary key, the payload will "replace" the entity specified by the
-given primary key. If the primary key is **not** that of an existing entity, `404
-NOT FOUND` will be returned.
+Inserts (or replaces) the SNI under the requested resource with the definition
+specified in the body. The SNI will be identified via the `name or id` attribute.
+
+When the `name or id` attribute has the structure of an UUID, the SNI being inserted/replaced
+will be identified by its `id`. Otherwise it will be identified by its `name`.
+
+When creating a new SNI, if an `id` is not specified (neither in the URL or the body) then
+the newly created one will be random. If an `id` is provided, the newly created Service will have
+said `id`.
+
+Notice that specifying a `name` in the url and a different one on the request body is not allowed.
 
 #### Response
 
@@ -1810,18 +1840,17 @@ See POST and PATCH responses.
 
 ### Delete SNI
 
-<div class="endpoint delete">/snis/{name}</div>
+<div class="endpoint delete">/snis/{name or id}</div>
 
 Attributes | Description
 ---:| ---
-`name`<br>**required** | The name of the SNI object.
+`name or id`<br>**required** | The UUID of an SNI object or its unique name
 
 #### Response
 
 ```
 HTTP 204 No Content
 ```
-
 ---
 
 ## Upstream Objects

--- a/app/docs/0.14.x/auth.md
+++ b/app/docs/0.14.x/auth.md
@@ -1,0 +1,215 @@
+---
+title: Authentication Reference
+---
+
+# Authentication Reference
+
+Traffic to your upstream services (APIs or microservices) is typically controlled by the application and
+configuration of various Kong [authentication plugins][plugins]. Since Kong's Service entity represents
+a 1-to-1 mapping of your own upstream services, the simplest scenario is to configure authentication
+plugins on the Services of your choosing.
+
+## Generic authentication
+
+The most common scenario is to require authentication and to not allow access for any unauthenticated request.
+To achieve this any of the authentication plugins can be used. The generic scheme/flow of those plugins
+works as follows:
+
+1. Apply an auth plugin to a Service, or globally (you cannot apply one on consumers)
+2. Create a `consumer` entity
+3. Provide the consumer with authentication credentials for the specific authentication method
+4. Now whenever a request comes in Kong will check the provided credentials (depends on the auth type) and
+it will either block the request if it cannot validate, or add consumer and credential details
+in the headers and forward the request
+
+The generic flow above does not always apply, for example when using external authentication like LDAP,
+then there is no consumer to be identified, and only the credentials will be added in the forwarded headers.
+
+The authentication method specific elements and examples can be found in each [plugin's documentation][plugins].
+
+## Consumers
+
+The easiest way to think about consumers is to map them one-on-one to users. Yet, to Kong this does not matter.
+The core principle for consumers is that you can attach plugins to them, and hence customize request behaviour.
+So you might have mobile apps, and define one consumer for each app, or version of it. Or have a consumer per
+platform, e.g. an android consumer, an iOS consumer, etc.
+
+It is an opaque concept to Kong and hence they are called "consumers" and not "users".
+
+## Anonymous Access
+
+Kong has the ability to configure a given Service to allow **both** authenticated **and** anonymous access.
+You might use this configuration to grant access to anonymous users with a low rate-limit, and grant access
+to authenticated users with a higher rate limit.
+
+To configure a Service like this, you first apply your selected authentication plugin, then create a new
+consumer to represent annonymous users, then configure your authentication plugin to allow anonymous
+access. Here is an example, which assumes you have already configured a Service named `example-service` and
+the corresponding route:
+
+1. ### Create an example Service and a Route
+
+    Issue the following cURL request to create `example-service` pointing to mockbin.org, which will echo
+    the request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/ \
+      --data 'name=example-service' \
+      --data 'url=http://mockbin.org/request'
+    ```
+
+    Add a route to the Service:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/routes \
+      --data 'paths[]=/auth-sample'
+    ```
+
+    The url `http://localhost:8000/auth-sample` will now echo whatever is being requested.
+
+2. ### Configure the key-auth Plugin for your Service
+
+    Issue the following cURL request to add a plugin to a Service:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/plugins/ \
+      --data 'name=key-auth'
+    ```
+
+    Be sure to note the created Plugin `id` - you'll need it in step 5.
+
+3. ### Verify that the key-auth plugin is properly configured
+
+    Issue the following cURL request to verify that the [key-auth][key-auth]
+    plugin was properly configured on the Service:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/auth-sample
+    ```
+
+    Since you did not specify the required `apikey` header or parameter, and you have not yet
+    enabled anonymous access, the response should be `403 Forbidden`:
+
+    ```http
+    HTTP/1.1 403 Forbidden
+    ...
+
+    {
+      "message": "No API key found in headers or querystring"
+    }
+    ```
+
+4. ### Create an anonymous Consumer
+
+    Every request proxied by Kong must be associated with a Consumer. You'll now create a Consumer
+    named `anonymous_users` (that Kong will utilize when proxying anonymous access) by issuing the
+    following request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/consumers/ \
+      --data "username=anonymous_users"
+    ```
+
+    You should see a response similar to the one below:
+
+    ```http
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+    Connection: keep-alive
+
+    {
+      "username": "anonymous_users",
+      "created_at": 1428555626000,
+      "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+    }
+    ```
+
+    Be sure to note the Consumer `id` - you'll need it in the next step.
+
+5. ### Enable anonymous access
+
+    You'll now re-configure the key-auth plugin to permit anonymous access by issuing the following
+    request (**replace the sample uuids below by the `id` values from step 2 and 4**):
+
+    ```bash
+    $ curl -i -X PATCH \
+      --url http://localhost:8001/plugins/<your-plugin-id> \
+      --data "config.anonymous=<your-consumer-id>"
+    ```
+
+    The `config.anonymous=<your-consumer-id>` parameter instructs the key-auth plugin on this Service to permit
+    anonymous access, and to associate such access with the Consumer `id` we received in the previous step. It is
+    required that you provide a valid and pre-existing Consumer `id` in this step - validity of the Consumer `id`
+    is not currently checked when configuring anonymous access, and provisioning of a Consumer `id` that doesn't already
+    exist will result in an incorrect configuration.
+
+6. ### Check anonymous access
+
+    Confirm that your Service now permits anonymous access by issuing the following request:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/auth-sample
+    ```
+
+    This is the same request you made in step #3, however this time the request should succeed, because you
+    enabled anonymous access in step #5.
+
+    The response (which is the request as Mockbin received it) should have these elements:
+
+    ```json
+    {
+      ...
+      "headers": {
+        ...
+        "x-consumer-id": "713c592c-38b8-4f5b-976f-1bd2b8069494",
+        "x-consumer-username": "anonymous_users",
+        "x-anonymous-consumer": "true",
+        ...
+      },
+      ...
+    }
+    ```
+
+    It shows the request was succesful, but anonymous.
+
+## Multiple Authentication
+
+Kong supports multiple authentication plugins for a given Service, allowing
+different clients to utilize different authentication methods to access a given Service or Route.
+
+The behaviour of the auth plugins can be set to do either a logical `AND`, or a logical `OR` when evaluating
+multiple authentication credentials. The key to the behaviour is the `config.anonymous` property.
+
+- `config.anonymous` not set <br/>
+  If this property is not set (empty) then the auth plugins will always perform authentication and return
+  a `40x` response if not validated. This results in a logical `AND` when multiple auth plugins are being
+  invoked.
+- `config.anonymous` set to a valid consumer id <br/>
+  In this case the auth plugin will only perform authentication if it was not already authenticated. When
+  authentication fails, it will not return a `40x` response, but set the anonymous consumer as the consumer. This
+  results in a logical `OR` + 'anonymous access' when multiple auth plugins are being invoked.
+
+**NOTE 1**: Either all or none of the auth plugins must be configured for anonymous access. The behaviour is
+undefined if they are mixed.
+
+**NOTE 2**: When using the `AND` method, the last plugin executed will be the one setting the credentials
+passed to the upstream service. With the `OR` method, it will be the first plugin that succesfully authenticates
+the consumer, or the last plugin that will set its configured anonymous consumer.
+
+**NOTE 3**: When using the OAuth2 plugin in an `AND` fashion, then also the OAuth2 endpoints for requesting
+tokens etc. will require authentication by the other configured auth plugins.
+
+<div class="alert alert-warning">
+  When multiple authentication plugins are enabled in an <tt>OR</tt> fashion on a given Service, and it is desired that
+  anonymous access be forbidden, then the <a href="/plugins/request-termination"><tt>request-termination</tt> plugin</a> should be
+  configured on the anonymous consumer. Failure to do so will allow unauthorized requests.
+</div>
+
+[plugins]: https://getkong.org/plugins/
+[key-auth]: /plugins/key-authentication

--- a/app/docs/0.14.x/cli.md
+++ b/app/docs/0.14.x/cli.md
@@ -1,0 +1,231 @@
+---
+title: CLI Reference
+---
+
+# CLI Reference
+
+The provided CLI (*Command Line Interface*) allows you to start, stop, and
+manage your Kong instances. The CLI manages your local node (as in, on the
+current machine).
+
+If you haven't yet, we recommend you read the [configuration reference][configuration-reference].
+
+### Table of Contents
+
+- [Global flags](#global-flags)
+- [Available commands](#available-commands)
+  - [kong check](#kong-check)
+  - [kong prepare](#kong-prepare)
+  - [kong health](#kong-health)
+  - [kong migrations](#kong-migrations)
+  - [kong quit](#kong-quit)
+  - [kong reload](#kong-reload)
+  - [kong restart](#kong-restart)
+  - [kong start](#kong-start)
+  - [kong stop](#kong-stop)
+  - [kong version](#kong-version)
+
+### Global flags
+
+All commands take a set of special, optional flags as arguments:
+
+* `--help`: print the command's help message
+* `--v`: enable verbose mode
+* `--vv`: enable debug mode (noisy)
+
+[Back to TOC](#table-of-contents)
+
+### Available commands
+
+#### **kong check**
+
+```
+Usage: kong check <conf>
+
+Check the validity of a given Kong configuration file.
+
+<conf> (default /etc/kong.conf or /etc/kong/kong.conf) configuration file
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong prepare**
+
+This command prepares the Kong prefix folder, with its sub-folders and files.
+
+```
+Usage: kong prepare [OPTIONS]
+
+Prepare the Kong prefix in the configured prefix directory. This command can
+be used to start Kong from the nginx binary without using the 'kong start'
+command.
+
+Example usage:
+  kong prepare -p /usr/local/kong -c kong.conf && kong migrations up &&
+    nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
+
+Options:
+ -c,--conf    (optional string) configuration file
+ -p,--prefix  (optional string) override prefix directory
+ --nginx-conf (optional string) custom Nginx configuration template
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong health**
+
+```
+Usage: kong health [OPTIONS]
+
+Check if the necessary services are running for this node.
+
+Options:
+  -p,--prefix (optional string) prefix at which Kong should be running
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong migrations**
+
+```
+Usage: kong migrations COMMAND [OPTIONS]
+
+Manage Kong's database migrations.
+
+The available commands are:
+  list   List migrations currently executed.
+  up     Execute all missing migrations up to the latest available.
+  reset  Reset the configured database (irreversible).
+
+Options:
+  -c,--conf (optional string) configuration file
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong quit**
+
+```
+Usage: kong quit [OPTIONS]
+
+Gracefully quit a running Kong node (Nginx and other
+configured services) in given prefix directory.
+
+This command sends a SIGQUIT signal to Nginx, meaning all
+requests will finish processing before shutting down.
+If the timeout delay is reached, the node will be forcefully
+stopped (SIGTERM).
+
+Options:
+  -p,--prefix  (optional string) prefix Kong is running at
+  -t,--timeout (default 10) timeout before forced shutdown
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong reload**
+
+```
+Usage: kong reload [OPTIONS]
+
+Reload a Kong node (and start other configured services
+if necessary) in given prefix directory.
+
+This command sends a HUP signal to Nginx, which will spawn
+new workers (taking configuration changes into account),
+and stop the old ones when they have finished processing
+current requests.
+
+Options:
+  -c,--conf    (optional string) configuration file
+  -p,--prefix  (optional string) prefix Kong is running at
+  --nginx-conf (optional string) custom Nginx configuration template
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong restart**
+
+```
+Usage: kong restart [OPTIONS]
+
+Restart a Kong node in the given prefix directory.
+
+This command is equivalent to doing both 'kong stop' and
+'kong start'.
+
+Options:
+  -c,--conf        (optional string)   configuration file
+  -p,--prefix      (optional string)   prefix at which Kong should be running
+  --nginx-conf     (optional string)   custom Nginx configuration template
+  --run-migrations (optional boolean)  optionally run migrations on the DB
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong start**
+
+```
+Usage: kong start [OPTIONS]
+
+Start Kong (Nginx and other configured services) in the configured
+prefix directory.
+
+Options:
+  -c,--conf        (optional string)   configuration file
+  -p,--prefix      (optional string)   prefix at which Kong should be running
+  --nginx-conf     (optional string)   custom Nginx configuration template
+  --run-migrations (optional boolean)  optionally run migrations on the DB
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong stop**
+
+```
+Usage: kong stop [OPTIONS]
+
+Stop a running Kong node (Nginx and other configured services) in given
+prefix directory.
+
+This command sends a SIGTERM signal to Nginx.
+
+Options:
+  -p,--prefix (optional string) prefix Kong is running at
+```
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### **kong version**
+
+```
+Usage: kong version [OPTIONS]
+
+Print Kong's version. With the -a option, will print
+the version of all underlying dependencies.
+
+Options:
+  -a,--all    get version of all dependencies
+```
+
+[Back to TOC](#table-of-contents)
+
+[configuration-reference]: /docs/{{page.kong_version}}/configuration

--- a/app/docs/0.14.x/clustering.md
+++ b/app/docs/0.14.x/clustering.md
@@ -1,0 +1,326 @@
+---
+title: Clustering Reference
+---
+
+# Clustering Reference
+
+A Kong cluster allows you to scale the system horizontally by adding more
+machines to handle more incoming requests. They will all share the same
+configuration since they point to the same database. Kong nodes pointing to the
+**same datastore** will be part of the same Kong cluster.
+
+You need a load-balancer in front of your Kong cluster to distribute traffic
+across your available nodes.
+
+### Table of Contents
+
+- [What a Kong cluster does and doesn't do][1]
+- [Single node Kong clusters][2]
+- [Multiple nodes Kong clusters][3]
+- [What is being cached?][4]
+- [How to configure database caching?][5]
+    - 1. [db_update_frequency][5-1]
+    - 2. [db_update_propagation][5-2]
+    - 3. [db_cache_ttl][5-3]
+    - 4. [When using Cassandra][5-4]
+- [Interacting with the cache via the Admin API][6]
+    - [Inspect a cached value][6-1]
+    - [Purge a cached value][6-2]
+    - [Purge a node's cache][6-3]
+
+[1]: #what-a-kong-cluster-does-and-doesnt-do
+[2]: #single-node-kong-clusters
+[3]: #multiple-nodes-kong-clusters
+[4]: #what-is-being-cached
+[5]: #how-to-configure-database-caching
+[5-1]: #1-db_update_frequency-default-5s
+[5-2]: #2-db_update_propagation-default-0s
+[5-3]: #3-db_cache_ttl-default-3600s
+[5-4]: #4-when-using-cassandra
+[6]: #interacting-with-the-cache-via-the-admin-api
+[6-1]: #inspect-a-cached-value
+[6-2]: #purge-a-cached-value
+[6-3]: #purge-a-nodes-cache
+
+### What a Kong cluster does and doesn't do
+
+**Having a Kong cluster does not mean that your clients traffic will be
+load-balanced across your Kong nodes out of the box.** You still need a
+load-balancer in front of your Kong nodes to distribute your traffic. Instead,
+a Kong cluster means that those nodes will share the same configuration.
+
+For performance reasons, Kong avoids database connections when proxying
+requests, and caches the contents of your database in memory. The cached
+entities include Services, Routes, Consumers, Plugins, Credentials, etc... Since those
+values are in memory, any change made via the Admin API of one of the nodes
+needs to be propagated to the other nodes.
+
+This document describes how those cached entities are being invalidated and how
+to configure your Kong nodes for your use case, which lies somewhere between
+performance and consistency.
+
+[Back to TOC](#table-of-contents)
+
+### Single node Kong clusters
+
+A single Kong node connected to a database (Cassandra or PostgreSQL) creates a
+Kong cluster of one node. Any changes applied via the Admin API of this node
+will instantly take effect. Example:
+
+Consider a single Kong node `A`. If we delete a previously registered Service:
+
+```bash
+$ curl -X DELETE http://127.0.0.1:8001/services/test-service
+```
+
+Then any subsequent request to `A` would instantly return `404 Not Found`, as
+the node purged it from its local cache:
+
+```bash
+$ curl -i http://127.0.0.1:8000/test-service
+```
+
+[Back to TOC](#table-of-contents)
+
+### Multiple nodes Kong clusters
+
+In a cluster of multiple Kong nodes, other nodes connected to the same database
+would not instantly be notified that the Service was deleted by node `A`.  While
+the Service is **not** in the database anymore (it was deleted by node `A`), it is
+**still** in node `B`'s memory.
+
+All nodes perform a periodic background job to synchronize with changes that
+may have been triggered by other nodes. The frequency of this job can be
+configured via:
+
+* [db_update_frequency][db_update_frequency] (default: 5 seconds)
+
+Every `db_update_frequency` seconds, all running Kong nodes will poll the
+database for any update, and will purge the relevant entities from their cache
+if necessary.
+
+If we delete a Service from node `A`, this change will not be effective in node
+`B` until node `B`s next database poll, which will occur up to
+`db_update_frequency` seconds later (though it could happen sooner).
+
+This makes Kong clusters **eventually consistent**.
+
+[Back to TOC](#table-of-contents)
+
+### What is being cached?
+
+All of the core entities such as Services, Routes, Plugins, Consumers, Credentials are
+cached in memory by Kong and depend on their invalidation via the polling
+mechanism to be updated.
+
+Additionally, Kong also caches **database misses**. This means that if you
+configure a Service with no plugin, Kong will cache this information. Example:
+
+On node `A`, we add a Service and a Route:
+
+```bash
+# node A
+$ curl -X POST http://127.0.0.1:8001/services \
+    --data "name=example-service" \
+    --data "url=http://example.com"
+
+$ curl -X POST http://127.0.0.1:8001/services/example-service/routes \
+    --data "paths[]=/example"
+```
+
+(Note that we used `/services/example-service/routes` as a shortcut: we
+could have used the `/routes` endpoint instead, but then we would need to
+pass `service_id` as an argument, with the UUID of the new Service.)
+
+A request to the Proxy port of both node `A` and `B` will cache this Service, and
+the fact that no plugin is configured on it:
+
+```bash
+# node A
+$ curl http://127.0.0.1:8000/example
+HTTP 200 OK
+...
+```
+
+```bash
+# node B
+$ curl http://127.0.0.2:8000/example
+HTTP 200 OK
+...
+```
+
+Now, say we add a plugin to this Service via node `A`'s Admin API:
+
+```bash
+# node A
+$ curl -X POST http://127.0.0.1:8001/services/example-service/plugins \
+    --data "name=example-plugin"
+```
+
+Because this request was issued via node `A`'s Admin API, node `A` will locally
+invalidate its cache and on subsequent requests, it will detect that this API
+has a plugin configured.
+
+However, node `B` hasn't run a database poll yet, and still caches that this
+API has no plugin to run. It will be so until node `B` runs its database
+polling job.
+
+**Conclusion**: all CRUD operations trigger cache invalidations. Creation
+(`POST`, `PUT`) will invalidate cached database misses, and update/deletion
+(`PATCH`, `DELETE`) will invalidate cached database hits.
+
+[Back to TOC](#table-of-contents)
+
+### How to configure database caching?
+
+You can configure 3 properties in the Kong configuration file, the most
+important one being `db_update_frequency`, which determine where your Kong
+nodes stand on the performance vs consistency trade off.
+
+Kong comes with default values tuned for consistency, in order to let you
+experiment with its clustering capabilities while avoiding "surprises". As you
+prepare a production setup, you should consider tuning those values to ensure
+that your performance constraints are respected.
+
+#### 1. [db_update_frequency][db_update_frequency] (default: 5s)
+
+This value determines the frequency at which your Kong nodes will be polling
+the database for invalidation events. A lower value will mean that the polling
+job will be executed more frequently, but that your Kong nodes will keep up
+with changes you apply. A higher value will mean that your Kong nodes will
+spend less time running the polling jobs, and will focus on proxying your
+traffic.
+
+**Note**: changes propagate through the cluster in up to `db_update_frequency`
+seconds.
+
+[Back to TOC](#table-of-contents)
+
+#### 2. [db_update_propagation][db_update_propagation] (default: 0s)
+
+If your database itself is eventually consistent (ie: Cassandra), you **must**
+configure this value. It is to ensure that the change has time to propagate
+across your database nodes. When set, Kong nodes receiving invalidation events
+from their polling jobs will delay the purging of their cache for
+`db_update_propagation` seconds.
+
+If a Kong node connected to an eventual consistent database was not delaying
+the event handling, it could purge its cache, only to cache the non-updated
+value again (because the change hasn't propagated through the database yet)!
+
+You should set this value to an estimate of the amount of time your database
+cluster takes to propagate changes.
+
+**Note**: when this value is set, changes propagate through the cluster in
+up to `db_update_frequency + db_update_propagation` seconds.
+
+[Back to TOC](#table-of-contents)
+
+#### 3. [db_cache_ttl][db_cache_ttl] (default: 3600s)
+
+The time (in seconds) for which Kong will cache database entities (both hits
+and misses). This Time-To-Live value acts as a safeguard in case a Kong node
+misses an invalidation event, to avoid it from running on stale data for too
+long. When the TTL is reached, the value will be purged from its cache, and the
+next database result will be cached again.
+
+You can configure your cache to not invalidate data based on this TTL, by
+disabling it. To disable it, set this value to `0`. But be wary: if a Kong
+node misses an invalidation event for any reason, it might run with a stale
+value in its cache for an undefined amount of time, until the cache is
+manually purged, or the node is restarted.
+
+[Back to TOC](#table-of-contents)
+
+#### 4. When using Cassandra
+
+If you use Cassandra as your Kong database, you **must** set
+[db_update_propagation][db_update_propagation] to a non-zero value. Since
+Cassandra is eventually consistent by nature, this will ensure that Kong nodes
+do not prematurely invalidate their cache, only to fetch and catch a
+not up-to-date entity again. Kong will present you a warning logs if you did
+not configure this value when using Cassandra.
+
+Additionally, you might want to configure `cassandra_consistency` to a value
+like `QUORUM` or `LOCAL_QUORUM`, to ensure that values being cached by your
+Kong nodes are up-to-date values from your database.
+
+[Back to TOC](#table-of-contents)
+
+### Interacting with the cache via the Admin API
+
+If for some reason, you wish to investigate the cached values, or manually
+invalidate a value cached by Kong (a cached hit or miss), you can do so via the
+Admin API `/cache` endpoint.
+
+#### Inspect a cached value
+
+##### Endpoint
+
+<div class="endpoint get">/cache/{cache_key}</div>
+
+##### Response
+
+If a value with that key is cached:
+
+```
+HTTP 200 OK
+...
+{
+    ...
+}
+```
+
+Else:
+
+```
+HTTP 404 Not Found
+```
+
+**Note**: retrieving the `cache_key` for each entity being cached by Kong is
+currently an undocumented process. Future versions of the Admin API will make
+this process easier.
+
+[Back to TOC](#table-of-contents)
+
+#### Purge a cached value
+
+##### Endpoint
+
+<div class="endpoint delete">/cache/{cache_key}</div>
+
+##### Response
+
+```
+HTTP 204 No Content
+...
+```
+
+**Note**: retrieving the `cache_key` for each entity being cached by Kong is
+currently an undocumented process. Future versions of the Admin API will make
+this process easier.
+
+[Back to TOC](#table-of-contents)
+
+#### Purge a node's cache
+
+##### Endpoint
+
+<div class="endpoint delete">/cache</div>
+
+##### Response
+
+```
+HTTP 204 No Content
+```
+
+**Note**: be wary of using this endpoint on a warm, production running node.
+If the node is receiving a lot of traffic, purging its cache at the same time
+will trigger many requests to your database, and could cause a
+[dog-pile effect](https://en.wikipedia.org/wiki/Cache_stampede).
+
+[Back to TOC](#table-of-contents)
+
+[db_update_frequency]: /docs/{{page.kong_version}}/configuration/#db_update_frequency
+[db_update_propagation]: /docs/{{page.kong_version}}/configuration/#db_update_propagation
+[db_cache_ttl]: /docs/{{page.kong_version}}/configuration/#db_cache_ttl

--- a/app/docs/0.14.x/configuration.md
+++ b/app/docs/0.14.x/configuration.md
@@ -1,0 +1,1020 @@
+---
+title: Configuration Reference
+---
+
+# Configuration Reference
+
+### Table of Contents
+
+- [Configuration loading](#configuration-loading)
+- [Verifying your configuration](#verifying-your-configuration)
+- [Environment variables](#environment-variables)
+- [Custom Nginx configuration & embedding Kong](#custom-nginx-configuration-embedding-kong)
+  - [Custom Nginx configuration](#custom-nginx-configuration)
+  - [Embedding Kong in OpenResty](#embedding-kong-in-openresty)
+  - [Serving both a website and your APIs from Kong](#serving-both-a-website-and-your-apis-from-kong)
+- [Properties reference](#properties-reference)
+  - [General section](#general-section)
+  - [Nginx section](#nginx-section)
+  - [Datastore section](#datastore-section)
+  - [Datastore cache section](#datastore-cache-section)
+  - [DNS resolver section](#dns-resolver-section)
+  - [Development & miscellaneous section](#development-miscellaneous-section)
+
+### Configuration loading
+
+Kong comes with a default configuration file that can be found at
+`/etc/kong/kong.conf.default` if you installed Kong via one of the official
+packages. To start configuring Kong, you can copy this file:
+
+```
+$ cp /etc/kong/kong.conf.default /etc/kong/kong.conf
+```
+
+Kong will operate with default settings should all the values in your
+configuration be commented-out. Upon starting, Kong looks for several
+default locations that might contain a configuration file:
+
+```
+/etc/kong/kong.conf
+/etc/kong.conf
+```
+
+You can override this behavior by specifying a custom path for your
+configuration file using the `-c / --conf` argument in the CLI:
+
+```
+$ kong start --conf /path/to/kong.conf
+```
+
+The configuration format is straightforward: simply uncomment any property
+(comments are defined by the `#` character) and modify it to your needs.
+Booleans values can be specified as `on/off` or `true`/`false` for convenience.
+
+[Back to TOC](#table-of-contents)
+
+### Verifying your configuration
+
+You can verify the integrity of your settings with the `check` command:
+
+```
+$ kong check <path/to/kong.conf>
+configuration at <path/to/kong.conf> is valid
+```
+
+This command will take into account the environment variables you have
+currently set, and will error out in case your settings are invalid.
+
+Additionally, you can also use the CLI in debug mode to have more insight
+as to what properties Kong is being started with:
+
+```
+$ kong start -c <kong.conf> --vv
+2016/08/11 14:53:36 [verbose] no config file found at /etc/kong.conf
+2016/08/11 14:53:36 [verbose] no config file found at /etc/kong/kong.conf
+2016/08/11 14:53:36 [debug] admin_listen = "0.0.0.0:8001"
+2016/08/11 14:53:36 [debug] database = "postgres"
+2016/08/11 14:53:36 [debug] log_level = "notice"
+[...]
+```
+
+[Back to TOC](#table-of-contents)
+
+### Environment variables
+
+When loading properties out of a configuration file, Kong will also look for
+environment variables of the same name. This allows you to fully configure Kong
+via environment variables, which is very convenient for container-based
+infrastructures, for example.
+
+All environment variables prefixed with `KONG_`, capitalized and bearing the
+same name as a setting will override it.
+
+Example:
+
+```
+log_level = debug # in kong.conf
+```
+
+Can be overridden with:
+
+```
+$ export KONG_LOG_LEVEL=error
+```
+
+[Back to TOC](#table-of-contents)
+
+### Custom Nginx configuration & embedding Kong
+
+Tweaking the Nginx configuration is an essential part of setting up your Kong
+instances since it allows you to optimize its performance for your
+infrastructure, or embed Kong in an already running OpenResty instance.
+
+#### Custom Nginx configuration
+
+Kong can be started, reloaded and restarted with an `--nginx-conf` argument,
+which must specify an Nginx configuration template. Such a template uses the
+[Penlight][Penlight] [templating engine][pl.template], which is compiled using
+the given Kong configuration, before being dumped in your Kong prefix
+directory, moments before starting Nginx.
+
+The default template can be found at:
+https://github.com/Mashape/kong/tree/master/kong/templates. It is split in two
+Nginx configuration files: `nginx.lua` and `nginx_kong.lua`. The former is
+minimalistic and includes the latter, which contains everything Kong requires
+to run. When `kong start` runs, right before starting Nginx, it copies these
+two files into the prefix directory, which looks like so:
+
+```
+/usr/local/kong
+├── nginx-kong.conf
+├── nginx.conf
+```
+
+If you wish to include other `server` blocks in your Nginx configuration, or if
+you must tweak global settings that are not exposed by the Kong configuration,
+here is a suggestion:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{ "{{NGINX_WORKER_PROCESSES" }}}}; # can be set by kong.conf
+daemon ${{ "{{NGINX_DAEMON" }}}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{ "{{LOG_LEVEL" }}}}; # can be set by kong.conf
+
+events {
+    use epoll; # custom setting
+    multi_accept on;
+}
+
+http {
+    # include default Kong Nginx config
+    include 'nginx-kong.conf';
+
+    # custom server
+    server {
+        listen 8888;
+        server_name custom_server;
+
+        location / {
+          ... # etc
+        }
+    }
+}
+```
+
+You can then start Kong with:
+
+```
+$ kong start -c kong.conf --nginx-conf custom_nginx.template
+```
+
+If you wish to customize the Kong Nginx sub-configuration file to, eventually,
+add other Lua handlers or customize the `lua_*` directives, you can inline the
+`nginx_kong.lua` configuration in this `custom_nginx.template` example file:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{ "{{NGINX_WORKER_PROCESSES" }}}}; # can be set by kong.conf
+daemon ${{ "{{NGINX_DAEMON" }}}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{ "{{LOG_LEVEL" }}}}; # can be set by kong.conf
+
+events {}
+
+http {
+  resolver ${{ "{{DNS_RESOLVER" }}}} ipv6=off;
+  charset UTF-8;
+  error_log logs/error.log ${{ "{{LOG_LEVEL" }}}};
+  access_log logs/access.log;
+
+  ... # etc
+}
+```
+
+[Back to TOC](#table-of-contents)
+
+#### Embedding Kong in OpenResty
+
+If you are running your own OpenResty servers, you can also easily embed Kong
+by including the Kong Nginx sub-configuration using the `include` directive
+(similar to the examples of the previous section). If you have a valid
+top-level NGINX configuration that simply includes the Kong-specific
+configuration:
+
+```
+# my_nginx.conf
+
+http {
+    include 'nginx-kong.conf';
+}
+```
+
+you can start your instance like so:
+
+```
+$ nginx -p /usr/local/openresty -c my_nginx.conf
+```
+
+And Kong will be running in that instance (as configured in `nginx-kong.conf`).
+
+[Back to TOC](#table-of-contents)
+
+#### Serving both a website and your APIs from Kong
+
+A common use case for API providers is to make Kong serve both a website
+and the APIs themselves over the Proxy port &mdash; `80` or `443` in
+production. For example, `https://my-api.com` (Website) and
+`https://my-api.com/api/v1` (API).
+
+To achieve this, we cannot simply declare a new virtual server block,
+like we did in the previous section. A good solution is to use a custom
+Nginx configuration template which inlines `nginx_kong.lua` and adds a new
+`location` block serving the website alongside the Kong Proxy `location`
+block:
+
+```
+# ---------------------
+# custom_nginx.template
+# ---------------------
+
+worker_processes ${{ "{{NGINX_WORKER_PROCESSES" }}}}; # can be set by kong.conf
+daemon ${{ "{{NGINX_DAEMON" }}}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                      # this setting is mandatory
+error_log logs/error.log ${{ "{{LOG_LEVEL" }}}}; # can be set by kong.conf
+events {}
+
+http {
+  # here, we inline the contents of nginx_kong.lua
+  charset UTF-8;
+
+  # any contents until Kong's Proxy server block
+  ...
+
+  # Kong's Proxy server block
+  server {
+    server_name kong;
+
+    # any contents until the location / block
+    ...
+
+    # here, we declare our custom location serving our website
+    # (or API portal) which we can optimize for serving static assets
+    location / {
+      root /var/www/my-api.com;
+      index index.htm index.html;
+      ...
+    }
+
+    # Kong's Proxy location / has been changed to /api/v1
+    location /api/v1 {
+      set $upstream_host nil;
+      set $upstream_scheme nil;
+      set $upstream_uri nil;
+
+      # Any remaining configuration for the Proxy location
+      ...
+    }
+  }
+
+  # Kong's Admin server block goes below
+}
+```
+
+[Back to TOC](#table-of-contents)
+
+### Properties reference
+
+#### General section
+
+##### **prefix**
+
+Working directory. Equivalent to Nginx's prefix path, containing temporary files
+and logs. Each Kong process must have a separate working directory.
+
+Default: `/usr/local/kong`
+
+---
+
+##### **log_level**
+
+Log level of the Nginx server. Logs can be found at `<prefix>/logs/error.log`
+
+See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list of
+accepted values.
+
+Default: `notice`
+
+---
+
+##### **proxy_access_log**
+
+Path for proxy port request access logs. Set this value to `off` to disable
+logging proxy requests. If this value is a relative path, it will be placed
+under the `prefix` location.
+
+Default: `logs/access.log`
+
+---
+
+##### **proxy_error_log**
+
+Path for proxy port request error logs. Granularity of these logs is adjusted
+by the `log_level` directive.
+
+Default: `logs/error.log`
+
+---
+
+##### **admin_access_log**
+
+Path for Admin API request access logs. Set this value to `off` to disable
+logging Admin API requests. If this value is a relative path, it will be placed
+under the `prefix` location.
+
+Default: `logs/admin_access.log`
+
+---
+
+##### **admin_error_log**
+
+Path for Admin API request error logs. Granularity of these logs is adjusted by
+the `log_level` directive.
+
+Default: `logs/error.log`
+
+---
+
+##### **custom_plugins**
+
+Comma-separated list of additional plugins this node should load. Use this
+property to load custom plugins that are not bundled with Kong. Plugins will
+be loaded from the `kong.plugins.{name}.*` namespace.
+
+Default: none
+
+Example: `my-plugin,hello-world,custom-rate-limiting`
+
+---
+
+##### **anonymous_reports**
+
+Send anonymous usage data such as error stack traces to help improve Kong.
+
+Default: `on`
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### Nginx section
+
+##### **proxy_listen**
+
+Comma-separated list of addresses and ports on which the proxy server should
+listen. The proxy server is the public entrypoint of Kong, which proxies
+traffic from your consumers to your backend services. This value accepts IPv4,
+IPv6, and hostnames.
+
+Some suffixes can be specified for each pair:
+
+- `ssl` will require that all connections made through a particular
+  address/port be made with TLS enabled.
+- `http2` will allow for clients to open HTTP/2 connections to Kong's proxy
+  server.
+- Finally, `proxy_protocol` will enable usage of the PROXY protocol for a
+  given address/port.
+
+the proxy port for this node, enabling a 'control-plane' mode (without traffic
+proxying capabilities) which can configure a cluster of nodes connected to the
+same database.
+
+See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for
+a description of the accepted formats for this and other `*_listen` values.
+
+Default: `0.0.0.0:8000, 0.0.0.0:8443 ssl`
+
+Example: `0.0.0.0:80, 0.0.0.0:81 http2, 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`
+
+---
+
+##### **admin_listen**
+
+Comma-separated list of addresses and ports on which the Admin interface
+should listen. The Admin interface is the API allowing you to configure and
+manage Kong. Access to this interface should be *restricted* to Kong
+administrators *only*. This value accepts IPv4, IPv6, and hostnames. Some
+suffixes can be specified for each pair:
+
+- `ssl` will require that all connections made through a particular
+  address/port be made with TLS enabled.
+- `http2` will allow for clients to open HTTP/2 connections to Kong's
+  proxy server.
+- Finally, `proxy_protocol` will enable usage of the PROXY protocol for a
+  given address/port.
+
+This value can be set to `off`, thus disabling the Admin interface for this
+node, enabling a 'data-plane' mode (without configuration capabilities)
+pulling its configuration changes from the database.
+
+Default: `127.0.0.1:8001, 127.0.0.1:8444 ssl`
+
+Example: `127.0.0.1:8444 http2 ssl`
+
+---
+
+##### **nginx_user**
+
+Defines user and group credentials used by worker processes. If group is omitted, a
+group whose name equals that of user is used.
+
+Default: `nobody nobody`
+
+Example: `nginx www`
+
+---
+
+##### **nginx_worker_processes**
+
+Determines the number of worker processes spawned by Nginx.
+See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed
+usage of this directive and a description of accepted values.
+
+Default: `auto`
+
+---
+
+##### **nginx_daemon**
+
+Determines whether Nginx will run as a daemon or as a foreground process.
+Mainly useful for development or when running Kong inside a Docker environment.
+
+See http://nginx.org/en/docs/ngx_core_module.html#daemon.
+
+Default: `on`
+
+---
+
+##### **mem_cache_size**
+
+Size of the in-memory cache for database entities. The accepted units are `k` and
+`m`, with a minimum recommended value of a few MBs.
+
+Default: `128m`
+
+---
+
+##### **ssl**
+
+Determines if Nginx should be listening for HTTPS traffic on the
+`proxy_listen_ssl` address. If disabled, Nginx will only bind itself
+on `proxy_listen`, and all SSL settings will be ignored.
+
+Default: `on`
+
+---
+
+##### **ssl_cipher_suite**
+
+Defines the TLS ciphers served by Nginx. Accepted values are `modern`,
+`intermediate`, `old`, or `custom`.
+See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed
+descriptions of each cipher suite.
+
+Default: `modern`
+
+---
+
+##### **ssl_ciphers**
+
+Defines a custom list of TLS ciphers to be served by Nginx. This list must
+conform to the pattern defined by `openssl ciphers`. This value is ignored if
+`ssl_cipher_suite` is not `custom`.
+
+Default: none
+
+---
+
+##### **ssl_cert**
+
+If `ssl` is enabled, the absolute path to the SSL certificate for the
+`proxy_listen_ssl` address. If none is specified and `ssl` is enabled, Kong will
+generate a default certificate and key.
+
+Default: none
+
+---
+
+##### **ssl_cert_key**
+
+If `ssl` is enabled, the absolute path to the SSL key for the
+`proxy_listen_ssl` address.
+
+Default: none
+
+---
+
+##### **http2**
+
+Enables HTTP2 support for HTTPS traffic on the `proxy_listen_ssl` address.
+
+Default: `off`
+
+---
+
+##### **client_ssl**
+
+Determines if Nginx should send client-side SSL certificates when proxying
+requests.
+
+Default: `off`
+
+---
+
+##### **client_ssl_cert**
+
+If `client_ssl` is enabled, the absolute path to the client SSL certificate for
+the `proxy_ssl_certificate` directive. Note that this value is statically
+defined on the node, and currently cannot be configured on a per-API basis.
+
+Default: none
+
+---
+
+##### **client_ssl_cert_key**
+
+If `client_ssl` is enabled, the absolute path to the client SSL key for the
+`proxy_ssl_certificate_key` address. Note this value is statically defined on
+the node, and currently cannot be configured on a per-API basis.
+
+Default: none
+
+---
+
+##### **admin_ssl**
+
+Determines if Nginx should be listening for HTTPS traffic on the
+`admin_listen_ssl` address. If disabled, Nginx will only bind itself on
+`admin_listen`, and all SSL settings will be ignored.
+
+Default: `on`
+
+---
+
+##### **admin_ssl_cert**
+
+If `admin_ssl` is enabled, the absolute path to the SSL certificate for the
+`admin_listen_ssl` address. If none is specified and `admin_ssl` is enabled,
+Kong will generate a default certificate and key.
+
+Default: none
+
+---
+
+##### **admin_ssl_cert_key**
+
+If `admin_ssl` is enabled, the absolute path to the SSL key for the
+`admin_listen_ssl` address.
+
+Default: none
+
+---
+
+##### **admin_http2**
+
+Enables HTTP2 support for HTTPS traffic on the `admin_listen_ssl` address.
+
+Default: `off`
+
+---
+
+##### **upstream_keepalive**
+
+Sets the maximum number of idle keepalive connections to upstream servers that
+are preserved in the cache of each worker process. When this number is
+exceeded, the least recently used connections are closed.
+
+Default: `60`
+
+---
+
+##### **server_tokens**
+
+Enables or disables emitting Kong version on error pages and in the `Server`
+or `Via` (in case the request was proxied) response header field.
+
+Default: `on`
+
+---
+
+##### **latency_tokens**
+
+Enables or disables emitting Kong latency information in the `X-Kong-Proxy-Latency`
+and `X-Kong-Upstream-Latency` response header fields.
+
+Default: `on`
+
+---
+
+##### **trusted_ips**
+
+Defines trusted IP address blocks that are known to send correct
+`X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their
+`X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own
+`X-Forwarded-*` headers.
+
+This property also sets the `set_real_ip_from` directive(s) in the Nginx
+configuration. It accepts the same type of values (CIDR blocks) but as a
+comma-separated list.
+
+To trust *all* /!\ IPs, set this value to `0.0.0.0/0,::/0`.
+
+If the special value `unix:` is specified, all UNIX-domain sockets will be
+trusted.
+
+See [the Nginx docs](http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from)
+for more details on the `set_real_ip_from` directive.
+
+Default: none
+
+---
+
+##### **real_ip_header**
+
+Defines the request header field whose value will be used to replace the client
+address. This value sets the [ngx_http_realip_module][ngx_http_realip_module]
+directive of the same name in the Nginx configuration.
+
+If this value receives `proxy_protocol`, the `proxy_protocol` parameter will be
+appended to the `listen` directive of the Nginx template.
+
+See [the Nginx docs](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header)
+for a description of this directive.
+
+Default: `X-Real-IP`
+
+---
+
+##### **real_ip_recursive**
+
+This value sets the [ngx_http_realip_module][ngx_http_realip_module] directive
+of the same name in the Nginx configuration.
+
+See [the Nginx docs](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive)
+for a description of this directive.
+
+Default: `off`
+
+---
+
+##### **client_max_body_size**
+
+Defines the maximum request body size allowed by requests proxied by Kong, specified in the
+Content-Length request header. If a request exceeds this limit, Kong will respond with a
+413 (Request Entity Too Large). Setting this value to 0 disables checking the request body
+size.
+
+Note: See [the Nginx docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)
+for further description of this parameter. Numeric values may be suffixed with
+`k` or `m` to denote limits in terms of kilobytes or megabytes.
+
+Default: `0`
+
+---
+
+##### **client_body_buffer_size**
+
+Defines the buffer size for reading the request body. If the client request body is
+larger than this value, the body will be buffered to disk. Note that when the body is
+buffered to disk Kong plugins that access or manipulate the request body may not work, so
+it is advisable to set this value as high as possible (e.g., set it as high as
+`client_max_body_size` to force request bodies to be kept in memory). Do note that
+high-concurrency environments will require significant memory allocations to process
+many concurrent large request bodies.
+
+Note: See [the Nginx docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size)
+for further description of this parameter. Numeric values may be suffixed with
+`k` or `m` to denote limits in terms of kilobytes or megabytes.
+
+Default: `8k`
+
+---
+
+##### **error_default_type**
+
+Default MIME type to use when the request `Accept` header is missing and Nginx is
+returning an error for the request. Accepted values are `text/plain`,
+`text/html`, `application/json`, and `application/xml`.
+
+Default: `text/plain`
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### Datastore section
+
+Kong will store all of its data (such as APIs, Consumers and Plugins) in
+either Cassandra or PostgreSQL.
+
+All Kong nodes belonging to the same cluster must connect themselves to the
+same database.
+
+<div class="alert alert-warning">
+  <p><strong>Starting with Kong 0.12.0:</strong></p>
+  <ul>
+    <li>PostgreSQL 9.4 support should be considered deprecated. Users are encouraged to upgrade to 9.5+</li>
+    <li>Cassandra 2.1 support should be considered deprecated. Users are encouraged to upgrade to 2.2+</li>
+  </ul>
+</div>
+
+---
+
+##### **database**
+
+Determines which of PostgreSQL or Cassandra this node will use as its
+datastore. Accepted values are `postgres` and `cassandra`.
+
+Default: `postgres`
+
+---
+
+##### **Postgres settings**
+
+name                  |  description
+----------------------|-------------------
+**pg_host**           | Host of the Postgres server
+**pg_port**           | Port of the Postgres server
+**pg_user**           | Postgres user
+**pg_password**       | Postgres user's password
+**pg_database**       | Database to connect to. **must exist**
+**pg_ssl**            | Enable SSL connections to the server
+**pg_ssl_verify**     | If `pg_ssl` is enabled, toggle server certificate verification. See `lua_ssl_trusted_certificate` setting.
+
+---
+
+##### **Cassandra settings**
+
+name                            | description
+--------------------------------|------------------
+**cassandra_contact_points**    | Comma-separated list of contacts points to your Cassandra cluster.
+**cassandra_port**              | Port on which your nodes are listening.
+**cassandra_keyspace**          | Keyspace to use in your cluster. Will be created if doesn't exist.
+**cassandra_consistency**       | Consistency setting to use when reading/writing.
+**cassandra_timeout**           | Timeout (in ms) for reading/writing.
+**cassandra_ssl**               | Enable SSL connections to the nodes.
+**cassandra_ssl_verify**        | If `cassandra_ssl` is enabled, toggle server certificate verification. See `lua_ssl_trusted_certificate` setting.
+**cassandra_username**          | Username when using the PasswordAuthenticator scheme.
+**cassandra_password**          | Password when using the PasswordAuthenticator scheme.
+**cassandra_consistency**       | Consistency setting to use when reading/writing to the Cassandra cluster.
+**cassandra_lb_policy**         | Load balancing policy to use when distributing queries across your Cassandra cluster. Accepted values are `RoundRobin` and `DCAwareRoundRobin`. Prefer the later if and only if you are using a multi-datacenter cluster, and set the `cassandra_local_datacenter` if so.
+**cassandra_local_datacenter**  | When using the `DCAwareRoundRobin` policy, you must specify the name of the cluster local (closest) to this Kong node.
+**cassandra_repl_strategy**     | If creating the keyspace for the first time, specify a replication strategy.
+**cassandra_repl_factor**       | Specify a replication factor for the `SimpleStrategy`.
+**cassandra_data_centers**      | Specify data centers for the `NetworkTopologyStrategy`.
+**cassandra_schema_consensus_timeout** | Define the timeout (in ms) for the waiting period to each a schema consensus between your Cassandra nodes. This value is only used during migrations.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### Datastore cache section
+
+In order to avoid unecessary communication with the datastore, Kong caches
+entities (such as APIs, Consumers, Credentials, etc...) for a configurable
+period of time. It also handles invalidations if such an entity is updated.
+
+This section allows for configuring the behavior of Kong regarding the
+caching of such configuration entities.
+
+---
+
+##### **db_update_frequency**
+
+Frequency (in seconds) at which to check for
+updated entities with the datastore.
+When a node creates, updates, or deletes an
+entity via the Admin API, other nodes need
+to wait for the next poll (configured by
+this value) to eventually purge the old
+cached entity and start using the new one.
+
+Default: 5 seconds
+
+---
+
+##### **db_update_propagation**
+
+Time (in seconds) taken for an entity in the
+datastore to be propagated to replica nodes
+of another datacenter.
+When in a distributed environment such as
+a multi-datacenter Cassandra cluster, this
+value should be the maximum number of
+seconds taken by Cassandra to propagate a
+row to other datacenters.
+When set, this property will increase the
+time taken by Kong to propagate the change
+of an entity.
+Single-datacenter setups or PostgreSQL
+servers should suffer no such delays, and
+this value can be safely set to 0.
+
+Default: 0 seconds
+
+---
+
+##### **db_cache_ttl**
+
+Time-to-live (in seconds) of an entity from
+the datastore when cached by this node.
+Database misses (no entity) are also cached
+according to this setting.
+If set to 0, such cached entities/misses
+never expire.
+
+Default: 3600 seconds (1 hour)
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### DNS resolver section
+
+Kong will resolve hostnames as either `SRV` or `A` records (in that order, and
+`CNAME` records will be dereferenced in the process).
+In case a name was resolved as an `SRV` record it will also override any given
+port number by the `port` field contents received from the DNS server.
+
+The DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will
+be used to expand short names to fully qualified ones. So it will first try the
+entire `SEARCH` list for the `SRV` type, if that fails it will try the `SEARCH`
+list for `A`, etc.
+
+For the duration of the `ttl`, the internal DNS resolver will loadbalance each
+request it gets over the entries in the DNS record. For `SRV` records the
+`weight` fields will be honored, but it will only use the lowest `priority`
+field entries in the record.
+
+---
+
+##### **dns_resolver**
+
+Comma separated list of nameservers, each
+entry in `ip[:port]` format to be used by
+Kong. If not specified the nameservers in
+the local `resolv.conf` file will be used.
+Port defaults to 53 if omitted. Accepts
+both IPv4 and IPv6 addresses.
+
+Default: none
+
+---
+
+##### **dns_hostsfile**
+
+The hosts file to use. This file is read once and its content is static
+in memory. To read the file again after modifying it, Kong must be reloaded.
+
+Default: `/etc/hosts`
+
+---
+
+##### **dns_order**
+
+The order in which to resolve different
+record types. The `LAST` type means the
+type of the last successful lookup (for the
+specified name). The format is a (case
+insensitive) comma separated list.
+
+Default: `LAST,SRV,A,CNAME`
+
+---
+
+##### **dns_stale_ttl**
+
+Defines, in seconds, how long a record will
+remain in cache past its TTL. This value
+will be used while the new DNS record is
+fetched in the background.
+Stale data will be used from expiry of a
+record until either the refresh query
+completes, or the `dns_stale_ttl` number of
+seconds have passed.
+
+Default: `4`
+
+---
+
+##### **dns_not_found_ttl**
+
+TTL in seconds for empty DNS responses and
+"(3) name error" responses.
+
+Default: `30`
+
+---
+
+##### **dns_error_ttl**
+
+TTL in seconds for error responses.
+
+Default: `1`
+
+---
+
+##### **dns_no_sync**
+
+If enabled, then upon a cache-miss every
+request will trigger its own dns query.
+When disabled multiple requests for the
+same name/type will be synchronised to a
+single query.
+
+Default: off
+
+[Back to TOC](#table-of-contents)
+
+---
+
+#### Development & miscellaneous section
+
+Additional settings inherited from lua-nginx-module allowing for more
+flexibility and advanced usage.
+
+See the lua-nginx-module documentation for more informations:
+https://github.com/openresty/lua-nginx-module
+
+---
+
+##### **lua_ssl_trusted_certificate**
+
+Absolute path to the certificate authority file for Lua cosockets in PEM
+format. This certificate will be the one used for verifying Kong's database
+connections, when `pg_ssl_verify` or `cassandra_ssl_verify` are enabled.
+
+See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
+
+Default: none
+
+---
+
+##### **lua_ssl_verify_depth**
+
+Sets the verification depth in the server certificates chain used by Lua
+cosockets, set by `lua_ssl_trusted_certificate`.
+
+This includes the certificates configured for Kong's database connections.
+
+See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth
+
+Default: `1`
+
+---
+
+##### **lua_package_path**
+
+Sets the Lua module search path (LUA_PATH). Useful when developing or using
+custom plugins not stored in the default search path.
+
+See https://github.com/openresty/lua-nginx-module#lua_package_path
+
+Default: none
+
+---
+
+##### **lua_package_cpath**
+
+Sets the Lua C module search path (LUA_CPATH).
+
+See https://github.com/openresty/lua-nginx-module#lua_package_cpath
+
+Default: none
+
+---
+
+##### **lua_socket_pool_size**
+
+Specifies the size limit for every cosocket connection pool associated with
+every remote server.
+
+See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
+
+Default: `30`
+
+[Back to TOC](#table-of-contents)
+
+[ngx_http_realip_module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html
+
+[Penlight]: http://stevedonovan.github.io/Penlight/api/index.html
+[pl.template]: http://stevedonovan.github.io/Penlight/api/libraries/pl.template.html

--- a/app/docs/0.14.x/getting-started/adding-consumers.md
+++ b/app/docs/0.14.x/getting-started/adding-consumers.md
@@ -1,0 +1,99 @@
+---
+title: Adding Consumers
+---
+
+# Adding Consumers
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/docs/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
+  </ol>
+</div>
+
+In the last section, we learned how to add plugins to Kong, in this section
+we're going to learn how to add consumers to your Kong instances. Consumers are
+associated to individuals using your API, and can be used for tracking, access
+management, and more.
+
+**Note:** This section assumes you have [enabled][enabling-plugins] the
+[key-auth][key-auth] plugin. If you haven't, you can either [enable the
+plugin][enabling-plugins] or skip steps two and three.
+
+1. ### Create a Consumer through the RESTful API
+
+    Lets create a user named `Jason` by issuing the following request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/consumers/ \
+      --data "username=Jason"
+    ```
+
+    You should see a response similar to the one below:
+
+    ```http
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+    Connection: keep-alive
+
+    {
+      "username": "Jason",
+      "created_at": 1428555626000,
+      "id": "bbdf1c48-19dc-4ab7-cae0-ff4f59d87dc9"
+    }
+    ```
+
+    Congratulations! You've just added your first consumer to Kong.
+
+    **Note:** Kong also accepts a `custom_id` parameter when [creating
+    consumers][API-consumers] to associate a consumer with your existing user
+    database.
+
+2. ### Provision key credentials for your Consumer
+
+    Now, we can create a key for our recently created consumer `Jason` by
+    issuing the following request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/consumers/Jason/key-auth/ \
+      --data 'key=ENTER_KEY_HERE'
+    ```
+
+3. ### Verify that your Consumer credentials are valid
+
+    We can now issue the following request to verify that the credentials of
+    our `Jason` Consumer is valid:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000 \
+      --header "Host: example.com" \
+      --header "apikey: ENTER_KEY_HERE"
+    ```
+
+### Next Steps
+
+Now that we've covered the basics of adding Services, Routes, Consumers and enabling
+Plugins, feel free to read more on Kong in one of the following documents:
+
+- [Configuration file Reference][configuration]
+- [CLI Reference][CLI]
+- [Proxy Reference][proxy]
+- [Admin API Reference][API]
+- [Clustering Reference][cluster]
+
+Questions? Issues? Contact us on one of the [Community Channels](/community)
+for help!
+
+[key-auth]: /plugins/key-authentication
+[API-consumers]: /docs/{{page.kong_version}}/admin-api#create-consumer
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins
+[configuration]: /docs/{{page.kong_version}}/configuration
+[CLI]: /docs/{{page.kong_version}}/cli
+[proxy]: /docs/{{page.kong_version}}/proxy
+[API]: /docs/{{page.kong_version}}/admin-api
+[cluster]: /docs/{{page.kong_version}}/clustering

--- a/app/docs/0.14.x/getting-started/configuring-a-service.md
+++ b/app/docs/0.14.x/getting-started/configuring-a-service.md
@@ -1,0 +1,139 @@
+---
+title: Configuring a Service
+---
+
+# Configuring a Service
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/install/">installed Kong</a> &mdash; It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll be adding an API to Kong. In order to do this, you'll
+first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
+it manages.
+
+For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
+an "echo" type public website which returns the requests it gets back to the requester, as reponses. This
+makes it helpful for learning how Kong proxies your API requests.
+
+Before you can start making requests against the Service, you will need to add a _Route_ to it.
+Routes specify how (and _if_) requests are sent to their Services after they reach Kong. A single
+Service can have many Routes.
+
+After configuring the Service and the Route, you'll be able to make requests through Kong using them.
+
+Kong exposes a [RESTful Admin API][API] on port `:8001`. Kong is configuration, including adding Services and
+Routes, is made via requests on that API.
+
+1. ### Add your Service using the Admin API
+
+    Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
+    to Kong:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/ \
+      --data 'name=example-service' \
+      --data 'url=http://mockbin.org'
+    ```
+
+    You should receive a response similar to:
+
+    ```http
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+    Connection: keep-alive
+
+    {
+       "host":"mockbin.org",
+       "created_at":1519130509,
+       "connect_timeout":60000,
+       "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
+       "protocol":"http",
+       "name":"example-service",
+       "read_timeout":60000,
+       "port":80,
+       "path":null,
+       "updated_at":1519130509,
+       "retries":5,
+       "write_timeout":60000
+    }
+    ```
+
+
+2. ### Add a Route for the Service
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/routes \
+      --data 'hosts[]=example.com'
+    ```
+
+    The answer should be similar to:
+
+    ```http
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+    Connection: keep-alive
+
+    {
+       "created_at":1519131139,
+       "strip_path":true,
+       "hosts":[
+          "example.com"
+       ],
+       "preserve_host":false,
+       "regex_priority":0,
+       "updated_at":1519131139,
+       "paths":null,
+       "service":{
+          "id":"79d7ee6e-9fc7-4b95-aa3b-61d2e17e7516"
+       },
+       "methods":null,
+       "protocols":[
+          "http",
+          "https"
+       ],
+       "id":"f9ce2ed7-c06e-4e16-bd5d-3a82daef3f9d"
+    }
+    ```
+
+    Kong is now aware of your Service and ready to proxy requests.
+
+3. ### Forward your requests through Kong
+
+    Issue the following cURL request to verify that Kong is properly forwarding
+    requests to your Service. Note that [by default][proxy-port] Kong handles proxy
+    requests on port `:8000`:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/ \
+      --header 'Host: example.com'
+    ```
+
+    A successful response means Kong is now forwarding requests made to
+    `http://localhost:8000` to the `url` we configured in step #1,
+    and is forwarding the response back to us. Kong knows to do this through
+    the header defined in the above cURL request:
+
+    <ul>
+      <li><strong>Host: &lt;given host></strong></li>
+    </ul>
+
+<hr>
+
+## Next Steps
+
+Now that you've added your Service to Kong, let's learn how to enable plugins.
+
+Go to [Enabling Plugins &rsaquo;][enabling-plugins]
+
+[API]: /docs/{{page.kong_version}}/admin-api
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins
+[proxy-port]: /docs/{{page.kong_version}}/configuration/#nginx-section
+[mockbin]: https://mockbin.com/

--- a/app/docs/0.14.x/getting-started/enabling-plugins.md
+++ b/app/docs/0.14.x/getting-started/enabling-plugins.md
@@ -1,0 +1,75 @@
+---
+title: Enabling Plugins
+---
+
+# Enabling Plugins
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong>
+  <ol>
+    <li>Make sure you've <a href="/install/">installed Kong</a> - It should only take a minute!</li>
+    <li>Make sure you've <a href="/docs/{{page.kong_version}}/getting-started/quickstart">started Kong</a>.</li>
+    <li>Also, make sure you've <a href="/docs/{{page.kong_version}}/getting-started/configuring-a-service">configured your Service in Kong</a>.</li>
+  </ol>
+</div>
+
+In this section, you'll learn how to configure Kong plugins. One of the core
+principles of Kong is its extensibility through [plugins][plugins]. Plugins
+allow you to easily add new features to your API or make your API easier to
+manage.
+
+In the steps below you will configure the [key-auth][key-auth] plugin to add
+authentication to your Service. Prior to the addition of this plugin, **all**
+requests to your Service would be proxied upstream. Once you add and configure this
+plugin, **only** requests with the correct API key(s) will be proxied - all
+other requests will be rejected by Kong, thus protecting your upstream service
+from unauthorized use.
+
+
+1. ### Configure the key-auth plugin for the Service you <a href="/docs/{{page.kong_version}}/getting-started/configured-a-service">configured in Kong</a>.
+
+    Issue the following cURL request:
+
+    ```bash
+    $ curl -i -X POST \
+      --url http://localhost:8001/services/example-service/plugins/ \
+      --data 'name=key-auth'
+    ```
+
+    **Note:** This plugin also accepts a `config.key_names` parameter, which
+    defaults to `['apikey']`. It is a list of headers and parameters names (both
+    are supported) that are supposed to contain the apikey during a request.
+
+2. ### Verify that the plugin is properly configured
+
+    Issue the following cURL request to verify that the [key-auth][key-auth]
+    plugin was properly configured on the Service:
+
+    ```bash
+    $ curl -i -X GET \
+      --url http://localhost:8000/ \
+      --header 'Host: example.com'
+    ```
+
+    Since you did not specify the required `apikey` header or parameter, the
+    response should be `401 Unauthorized`:
+
+    ```http
+    HTTP/1.1 401 Unauthorized
+    ...
+
+    {
+      "message": "No API key found in request"
+    }
+    ```
+
+### Next Steps
+
+Now that you've configured the **key-auth** plugin lets learn how to add
+consumers to your Service so we can continue proxying requests through Kong.
+
+Go to [Adding Consumers &rsaquo;][adding-consumers]
+
+[key-auth]: /plugins/key-authentication
+[plugins]: /plugins
+[adding-consumers]: /docs/{{page.kong_version}}/getting-started/adding-consumers

--- a/app/docs/0.14.x/getting-started/introduction.md
+++ b/app/docs/0.14.x/getting-started/introduction.md
@@ -1,0 +1,33 @@
+---
+title: Welcome to Kong
+---
+
+# Welcome to Kong
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've <a href="/install/">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+Before going further into Kong, make sure you understand its [purpose and philosophy](/about). Once you are confident with the concept of API Gateways, this guide is going to take you through a quick introduction on how to use Kong and perform basic operations such as:
+
+- [Running your own Kong instance][quickstart].
+- [Adding and consuming Services][configuring-a-service].
+- [Installing plugins on Kong][enabling-plugins].
+
+### What is Kong, technically?
+
+You’ve probably heard that Kong is built on Nginx, leveraging its stability and efficiency. But how is this possible exactly?
+
+To be more precise, Kong is a Lua application running in Nginx and made possible by the [lua-nginx-module](https://github.com/openresty/lua-nginx-module). Instead of compiling Nginx with this module, Kong is distributed along with [OpenResty](https://openresty.org/), which already includes lua-nginx-module. OpenResty is *not* a fork of Nginx, but a bundle of modules extending its capabilities.
+
+This sets the foundations for a pluggable architecture, where Lua scripts (referred to as *”plugins”*) can be enabled and executed at runtime. Because of this, we like to think of Kong as **a paragon of microservice architecture**: at its core, it implements database abstraction, routing and plugin management. Plugins can live in separate code bases and be injected anywhere into the request lifecycle, all in a few lines of code.
+
+### Next Steps
+
+Now, lets get familiar with learning how to "start" and "stop" Kong.
+
+Go to [5-minute quickstart with Kong &rsaquo;][quickstart]
+
+[quickstart]: /docs/{{page.kong_version}}/getting-started/quickstart
+[configuring-a-service]: /docs/{{page.kong_version}}/getting-started/configuring-a-service
+[enabling-plugins]: /docs/{{page.kong_version}}/getting-started/enabling-plugins

--- a/app/docs/0.14.x/getting-started/quickstart.md
+++ b/app/docs/0.14.x/getting-started/quickstart.md
@@ -1,0 +1,81 @@
+---
+title: 5-minute Quickstart
+---
+
+# 5-minute Quickstart
+
+<div class="alert alert-warning">
+  <strong>Before you start:</strong> Make sure you've
+  <a href="/install/">installed Kong</a> &mdash; It should only take a minute!
+</div>
+
+In this section, you'll learn how to manage your Kong instance. First we'll
+have you start Kong giving in order to give you access to the RESTful Admin
+interface, through which you manage your Services, Routes, Consumers, and more. Data sent
+through the Admin API is stored in Kong's [datastore][datastore-section] (Kong
+supports PostgreSQL and Cassandra).
+
+1. ### Start Kong
+
+    Issue the following command to prepare your datastore by running the Kong
+    migrations:
+
+    ```bash
+    $ kong migrations up [-c /path/to/kong.conf]
+    ```
+
+    You should see a message that tells you Kong has sucessfully migrated your
+    database. If not, you probably incorrectly configured your database
+    connection settings in your configuration file.
+
+    Now let's [start][CLI] Kong:
+
+    ```bash
+    $ kong start [-c /path/to/kong.conf]
+    ```
+
+    **Note:** the CLI accepts a configuration option (`-c /path/to/kong.conf`)
+    allowing you to point to your own configuration.
+
+2. ### Verify that Kong has started successfully
+
+    If everything went well, you should see a message (`Kong started`)
+    informing you that Kong is running.
+
+    By default Kong listens on the following ports:
+
+- `:8000` on which Kong listens for incoming HTTP traffic from your
+  clients, and forwards it to your upstream services.
+- `:8443` on which Kong listens for incoming HTTPS traffic. This port has a
+  similar behavior as the `:8000` port, except that it expects HTTPS
+  traffic only. This port can be disabled via the configuration file.
+- `:8001` on which the [Admin API][API] used to configure Kong listens.
+- `:8444` on which the Admin API listens for HTTPS traffic.
+
+3. ### Stop Kong
+
+    As needed you can stop the Kong process by issuing the following
+    [command][CLI]:
+
+    ```bash
+    $ kong stop
+    ```
+
+4. ### Reload Kong
+
+    Issue the following command to [reload][CLI] Kong without downtime:
+
+    ```bash
+    $ kong reload
+    ```
+
+### Next Steps
+
+Now that you have Kong running you can interact with the Admin API.
+
+To begin, go to [Configuring a Service &rsaquo;][configuring-a-service]
+
+[CLI]: /docs/{{page.kong_version}}/cli
+[API]: /docs/{{page.kong_version}}/admin-api
+[datastore-section]: /docs/{{page.kong_version}}/configuration/#datastore-section
+[configuring-a-service]: /docs/{{page.kong_version}}/getting-started/configuring-a-service

--- a/app/docs/0.14.x/health-checks-circuit-breakers.md
+++ b/app/docs/0.14.x/health-checks-circuit-breakers.md
@@ -1,0 +1,306 @@
+---
+title: Health Checks and Circuit Breakers Reference
+---
+
+# Health Checks and Circuit Breakers Reference
+
+You can make an API proxied by Kong use a [ring-balancer][ringbalancer], configured
+by adding an [upstream][upstream] entity that contains one or more [target][ringtarget]
+entities, each target pointing to a different IP address (or hostname) and
+port. The ring-balancer will balance load among the various targets, and based
+on the [upstream][upstream] configuration, will perform health checks on the targets,
+making them as healthy or unhealthy whether they are responsive or not. The
+ring-balancer will then only route traffic to healthy targets.
+
+Kong supports two kinds of health checks, which can be used separately or in
+conjunction:
+
+* **active checks**, where a specific HTTP endpoint in the target is
+periodically requested and the health of the target is determined based on its
+response;
+
+* **passive checks** (also known as **circuit breakers**), where Kong analyzes
+the ongoing traffic being proxied and determines the health of targets based
+on their behavior responding requests.
+
+### Table of Contents
+
+- [Healthy and unhealthy targets](#healthy-and-unhealthy-targets)
+- [Types of health checks](#types-of-health-checks)
+  - [Active health checks](#active-health-checks)
+  - [Passive health checks (circuit breakers)](#passive-health-checks-circuit-breakers)
+  - [Summary of pros and cons](#summary-of-pros-and-cons)
+- [Enabling and disabling health checks](#enabling-and-disabling-health-checks)
+  - [Enabling active health checks](#enabling-active-health-checks)
+  - [Enabling passive health checks](#enabling-passive-health-checks)
+  - [Disabling health checks](#disabling-health-checks)
+
+### Healthy and unhealthy targets
+
+The objective of the health checks functionality is to dynamically mark
+targets as healthy or unhealthy, **for a given Kong node**. There is
+no cluster-wide synchronization of health information: each Kong node
+determines the health of its targets separately. This is desirable since at a
+given point one Kong node may be able to connect to a target successfully
+while another node is failing to reach it: the first node will consider
+it healthy, while the second will mark it as unhealthy and start routing
+traffic to other targets of the upstream.
+
+Either an active probe (on active health checks) or a proxied request
+(on passive health checks) produces data which is used to determine
+whether a target is healthy or unhealthy. A request may produce a TCP
+error, timeout, or produce an HTTP status code. Based on this
+information, the health checker updates a series of internal counters:
+
+* If the returned status code is one configured as "healthy", it will
+increment the "Successes" counter for the target and clear all its other
+counters;
+* If it fails to connect, it will increment the "TCP failures" counter
+for the target and clear the "Successes" counter;
+* If it times out, it will increment the "timeouts" counter
+for the target and clear the "Successes" counter;
+* If the returned status code is one configured as "unhealthy", it will
+increment the "HTTP failures" counter for the target and clear the "Successes" counter.
+
+If any of the "TCP failures", "HTTP failures" or "timeouts" counters reaches
+their configured threshold, the target will be marked as unhealthy.
+
+If the "Sucesses" counter reaches its configured threshold, the target will be
+marked as healthy.
+
+The list of which HTTP status codes are "healthy" or "unhealthy", and the
+individual thresholds for each of these counters are configurable on a
+per-upstream basis. Below, we have an example of a configuration for an
+Upstream entity, showcasing the default values of the various fields
+available for configuring health checks. A description of each
+field is included in the [Admin API][addupstream] reference documentation.
+
+```json
+{
+    "name": "service.v1.xyz",
+    "healthchecks": {
+        "active": {
+            "concurrency": 10,
+            "healthy": {
+                "http_statuses": [ 200, 302 ],
+                "interval": 0,
+                "successes": 0
+            },
+            "http_path": "/",
+            "timeout": 1,
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 404, 500, 501,
+                                   502, 503, 504, 505 ],
+                "interval": 0,
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        },
+        "passive": {
+            "healthy": {
+                "http_statuses": [ 200, 201, 202, 203,
+                                   204, 205, 206, 207,
+                                   208, 226, 300, 301,
+                                   302, 303, 304, 305,
+                                   306, 307, 308 ],
+                "successes": 0
+            },
+            "unhealthy": {
+                "http_failures": 0,
+                "http_statuses": [ 429, 500, 503 ],
+                "tcp_failures": 0,
+                "timeouts": 0
+            }
+        }
+    },
+    "slots": 10
+}
+```
+
+If all targets of an upstream are unhealthy, Kong will respond to requests
+to the upstream with `503 Service Unavailable`.
+
+Note:
+
+1. health checks operate only on [*active* targets][targetobject] and do not
+   modify the *active* status of a target in the Kong database.
+2. unhealthy targets will not be removed from the loadbalancer, and hence will
+   not have any impact on the balancer layout when using the hashing algorithm
+   (they will just be skipped).
+3. The [DNS caveats][dnscaveats] and [balancer caveats][balancercaveats]
+   also apply to health checks. If using hostnames for the targets, then make
+   sure the DNS server always returns the full set of IP addresses for a name,
+   and does not limit the response. *Failing to do so might lead to health
+   checks not being executed.*
+
+### Types of health checks
+
+#### Active health checks
+
+Active health checks, as the name implies, actively probe targets for
+their health. When active health checks are enabled in an upstream entity,
+Kong will periodically issue HTTP requests to a configured path at each target
+of the upstream. This allows Kong to automatically enable and disable targets
+in the balancer based on the [probe results](#healthy-and-unhealthy-targets).
+
+The periodicity of active health checks can be configured separately for
+when a target is healthy or unhealthy. If the `interval` value for either
+is set to zero, the checking is disabled at the corresponding scenario.
+When both are zero, active health checks are disabled altogether.
+
+[Back to TOC](#table-of-contents)
+
+#### Passive health checks (circuit breakers)
+
+Passive health checks, also known as circuit breakers, are
+checks performed based on the requests being proxied by Kong,
+with no additional traffic being generated. When a target becomes
+unresponsive, the passive health checker will detect that and mark
+the target as unhealthy. The ring-balancer will start skipping this
+target, so no more traffic will be routed to it. 
+
+Once the problem with a target is solved and it is ready to receive
+traffic again, the Kong administrator can manually inform the
+health checker that the target should be enabled again, via an
+Admin API endpoint:
+
+```bash
+$ curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
+HTTP/1.1 204 No Content
+```
+
+This command will broadcast a cluster-wide message so that the "healthy"
+status is propagated to the whole [Kong cluster][clustering]. This will cause Kong nodes to
+reset the health counters of the health checkers running in all workers of the
+Kong node, allowing the ring-balancer to route traffic to the target again.
+
+Passive health checks have the advantage of not producing extra
+traffic, but they are unable to automatically mark a target as
+healthy again: the "circuit is broken", and the target needs to
+be re-enabled again by the system administrator.
+
+[Back to TOC](#table-of-contents)
+
+#### Summary of pros and cons
+
+* Active health checks can automatically re-enable a target in the
+ring balancer as soon as it is healthy again. Passive health checks cannot.
+* Passive health checks do not produce additional traffic to the 
+target. Active health checks do.
+* An active health checker demands a known URL with a reliable status response
+in the target to be configured as a probe endpoint (which may be as
+simple as `"/"`). Passive health checks do not demand such configuration.
+* By providing a custom probe endpoint for an active health checker,
+an application may determine its own health metrics and produce a status
+code to be consumed by Kong. Even though a target continues to serve
+traffic which looks healthy to the passive health checker,
+it would be able to respond to the active probe with a failure
+status, essentially requesting to be relieved from taking new traffic.
+
+It is possible to combine the two modes. For example, one can enable
+passive health checks to monitor the target health based solely on its
+traffic, and only use active health checks while the target is unhealthy,
+in order to re-enable it automatically.
+
+### Enabling and disabling health checks
+
+#### Enabling active health checks
+
+To enable active health checks, you need to specify the configuration items
+under `healthchecks.active` in the [Upstream object][upstreamobjects] configuration. You
+need to specify the necessary information so that Kong can perform periodic
+probing on the target, and how to interpret the resulting information.
+
+For configuring the probe, you need to specify:
+
+* `healthchecks.active.http_path` - The path that should be used when
+issuing the HTTP GET request to the target. The default value is `"/"`.
+* `healthchecks.active.timeout` - The connection timeout limit for the
+HTTP GET request of the probe. The default value is 1 second.
+* `healthchecks.active.concurrency` - Number of targets to check concurrently
+in active health checks.
+
+You also need to specify positive values for intervals, for running
+probes:
+
+* `healthchecks.active.healthy.interval` - Interval between active health
+checks for healthy targets (in seconds). A value of zero indicates that active
+probes for healthy targets should not be performed.
+* `healthchecks.active.unhealthy.interval` - Interval between active health
+checks for unhealthy targets (in seconds). A value of zero indicates that active
+probes for unhealthy targets should not be performed.
+
+This allows you to tune the behavior of the active health checks, whether you
+want probes for healthy and unhealthy targets to run at the same interval, or
+one to be more frequent than the other.
+
+Finally, you need to configure how Kong should interpret the probe, by setting
+the various thresholds on the [health
+counters](#healthy-and-unhealthy-targets), which, once reached will trigger a
+status change. The counter threshold fields are:
+
+* `healthchecks.active.healthy.successes` - Number of successes in active
+probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider
+a target healthy.
+* `healthchecks.active.unhealthy.tcp_failures` - Number of TCP failures in
+active probes to consider a target unhealthy.
+* `healthchecks.active.unhealthy.timeouts` - Number of timeouts in active
+probes to consider a target unhealthy.
+* `healthchecks.active.unhealthy.http_failures` - Number of HTTP failures in
+active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to
+consider a target unhealthy.
+
+#### Enabling passive health checks
+
+Passive health checks do not feature a probe, as they work by interpreting
+the ongoing traffic that flows from a target. This means that to enable
+passive checks you only need to configure its counter thresholds:
+
+* `healthchecks.passive.healthy.successes` - Number of successes in proxied
+traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to
+consider a target healthy, as observed by passive health checks. This needs to
+be positive when passive checks are enabled so that healthy traffic resets the
+unhealthy counters.
+* `healthchecks.passive.unhealthy.tcp_failures` - Number of TCP failures in
+proxied traffic to consider a target unhealthy, as observed by passive health
+checks.
+* `healthchecks.passive.unhealthy.timeouts` - Number of timeouts in proxied
+traffic to consider a target unhealthy, as observed by passive health checks.
+* `healthchecks.passive.unhealthy.http_failures` - Number of HTTP failures in
+proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`)
+to consider a target unhealthy, as observed by passive health checks.
+
+#### Disabling health checks
+
+In all counter thresholds and intervals specified in the `healthchecks`
+configuration, setting a value to zero means that the functionality the field
+represents is disabled. Setting a probe interval to zero disables a probe.
+Likewise, you can disable certain types of checks by setting their counter
+thresholds to zero. For example, to not consider timeouts when performing
+healthchecks, you can set both `timeouts` fields (for active and passive
+checks) to zero. This gives you a fine-grained control of the behavior of the
+health checker.
+
+In summary, to completely disable active health checks for an upstream, you
+need to set both `healthchecks.active.healthy.interval` and
+`healthchecks.active.unhealthy.interval` to `0`.
+
+To completely disable passive health checks, you need to set all counter
+thresholds under `healthchecks.passive` for its various counters to zero.
+
+All counter thresholds and intervals in `healthchecks` are zero by default,
+meaning that health checks are completely disabled by default in newly created
+upstreams.
+
+[Back to TOC](#table-of-contents)
+
+[ringbalancer]: /docs/{{page.kong_version}}/loadbalancing#ring-balancer
+[ringtarget]: /docs/{{page.kong_version}}/loadbalancing#target
+[upstream]: /docs/{{page.kong_version}}/loadbalancing#upstream
+[targetobject]: /docs/{{page.kong_version}}/admin-api#target-object
+[addupstream]: /docs/{{page.kong_version}}/admin-api#add-upstream
+[clustering]: /docs/{{page.kong_version}}/clustering
+[upstreamobjects]: /docs/{{page.kong_version}}/admin-api#upstream-objects
+[balancercaveats]: /docs/{{page.kong_version}}/loadbalancing#balancing-caveats
+[dnscaveats]: /docs/{{page.kong_version}}/loadbalancing#dns-caveats

--- a/app/docs/0.14.x/index.md
+++ b/app/docs/0.14.x/index.md
@@ -1,0 +1,65 @@
+---
+title: Documentation for Kong
+---
+
+<div class="docs-grid">
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/install/">Installation</a></h3>
+    <p>You can install Kong on most Linux distributions and OS X. We even provide the source so you can compile yourself.</p>
+    <a href="/install/">Install Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-quickstart.svg" /><a href="/docs/{{page.kong_version}}/getting-started/quickstart">5-minute Quickstart</a></h3>
+    <p>Learn how to start Kong, add your API, enable plugins, and add consumers in under thirty seconds.</p>
+    <a href="/docs/{{page.kong_version}}/getting-started/quickstart">Start using Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/configuration">Configuration file</a></h3>
+    <p>Want to further optimize your Kong cluster, database, or configure NGINX? Dive into the configuration.</p>
+    <a href="/docs/{{page.kong_version}}/configuration">Start configuring Kong &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/cli">CLI reference</a></h3>
+    <p>Want a better understanding of the CLI tool and its options? Browse the detailed command reference.</p>
+    <a href="/docs/{{page.kong_version}}/cli">Use the CLI &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/admin-api">Admin API reference</a></h3>
+    <p>Ready to learn the underlying interface? Browse the Admin API reference to learn how to start making requests.</p>
+    <a href="/docs/{{page.kong_version}}/admin-api">Explore the interface &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/proxy">Proxy reference</a></h3>
+    <p>Learn every way to configure Kong to proxy your APIs, serve them over SSL or use WebSockets.</p>
+    <a href="/docs/{{page.kong_version}}/proxy">Read the Proxy Reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/loadbalancing">Load balancing reference</a></h3>
+    <p>Learn how to setup Kong to load balance traffic through replicas of your upstream services.</p>
+    <a href="/docs/{{page.kong_version}}/loadbalancing">Read the Load balancing Reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-doc-reference.svg" /><a href="/docs/{{page.kong_version}}/health-checks-circuit-breakers">Health checks and circuit breakers</a></h3>
+    <p>Let Kong monitor the availability of your services and adjust its load balancing accordingly.</p>
+    <a href="/docs/{{page.kong_version}}/health-checks-circuit-breakers">Learn about health checks and circuit breakers &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-clustering.svg" /><a href="/docs/{{page.kong_version}}/clustering">Clustering</a></h3>
+    <p>If you are starting more than one node, you must use clustering to make sure all the nodes belong to the same Kong cluster.</p>
+    <a href="/docs/{{page.kong_version}}/clustering">Read the clustering reference &rarr;</a>
+  </div>
+
+  <div class="docs-grid-block">
+    <h3><img src="/assets/images/icons/documentation/icn-window.svg" /><a href="/docs/{{page.kong_version}}/plugin-development">Write your own plugins</a></h3>
+    <p>Looking for something Kong does not do for you? Easy: write it as a plugin. Learn how to write your own plugins for Kong.</p>
+    <a href="/docs/{{page.kong_version}}/plugin-development">Read the plugin development guide &rarr;</a>
+  </div>
+</div>

--- a/app/docs/0.14.x/loadbalancing.md
+++ b/app/docs/0.14.x/loadbalancing.md
@@ -1,0 +1,382 @@
+---
+title: Loadbalancing reference
+---
+
+# Load Balancing Reference
+
+Kong provides multiple ways of load balancing requests to multiple backend
+services: a straightforward DNS-based method, and a more dynamic ring-balancer
+that also allows for service registry without needing a DNS server.
+
+### Table of Contents
+
+- [DNS-based loadbalancing](#dns-based-loadbalancing)
+  - [A records](#a-records)
+  - [SRV records](#srv-records)
+  - [DNS priorities](#dns-priorities)
+  - [DNS caveats](#dns-caveats)
+- [Ring-balancer](#ring-balancer)
+  - [Upstream](#upstream)
+  - [Target](#target)
+  - [Balancing algorithms](#balancing-algorithms)
+  - [Balancing caveats](#balancing-caveats)
+- [Blue-green Deployments](#blue-green-deployments)
+- [Canary Releases](#canary-releases)
+
+### DNS-based loadbalancing
+
+When using DNS-based load balancing, the registration of the backend services
+is done outside of Kong, and Kong only receives updates from the DNS server.
+
+Every Service that has been defined with a `host` containing a hostname
+(instead of an IP address) will automatically use DNS-based load balancing
+if the name resolves to multiple IP addresses, provided the hostname does not
+resolve to an `upstream` name or a name in your DNS hostsfile.
+
+The DNS record `ttl` setting (time to live) determines how often the information
+is refreshed. When using a `ttl` of 0, every request will be resolved using its
+own DNS query. Obviously this will have a performance penalty, but the latency of
+updates/changes will be very low.
+
+[Back to TOC](#table-of-contents)
+
+#### **A records**
+
+An A record contains one or more IP addresses. Hence, when a hostname
+resolves to an A record, each backend service must have its own IP address.
+
+Because there is no `weight` information, all entries will be treated as equally
+weighted in the load balancer, and the balancer will do a straight forward
+round-robin.
+
+[Back to TOC](#table-of-contents)
+
+#### **SRV records**
+
+An SRV record contains weight and port information for all of its IP addresses.
+A backend service can be identified by a unique combination of IP address
+and port number. Hence, a single IP address can host multiple instances of the
+same service on different ports.
+
+Because the `weight` information is available, each entry will get its own
+weight in the load balancer and it will perform a weighted round-robin.
+
+Similarly, any given port information will be overridden by the port information from
+the DNS server. If a Service has attributes `host=myhost.com` and `port=123`,
+and `myhost.com` resolves to an SRV record with `127.0.0.1:456`, then the request
+will be proxied to `http://127.0.0.1:456/somepath`, as port `123` will be
+overridden by `456`.
+
+[Back to TOC](#table-of-contents)
+
+#### **DNS priorities**
+
+The DNS resolver will start resolving the following record types in order:
+
+  1. The last successful type previously resolved
+  2. SRV record
+  3. A record
+  4. CNAME record
+
+This order is configurable through the [`dns_order` configuration property][dns-order-config].
+
+[Back to TOC](#table-of-contents)
+
+#### **DNS caveats**
+
+- Whenever the DNS record is refreshed a list is generated to handle the
+weighting properly. Try to keep the weights as multiples of each other to keep
+the algorithm performant, e.g., 2 weights of 17 and 31 would result in a structure
+with 527 entries, whereas weights 16 and 32 (or their smallest relative
+counterparts 1 and 2) would result in a structure with merely 3 entries,
+especially with a very small (or even 0) `ttl` value.
+
+- Some nameservers do not return all entries (due to UDP packet size) in those
+cases (for example Consul returns a maximum of 3) a given Kong node will only
+use the few upstream service instances provided by the nameserver. In this
+scenario, it is possible that the pool of upstream instances will be loaded
+inconsistently, because the Kong node is effectively unaware of some of the
+instances, due to the limited information provided by the nameserver.
+To mitigate this use a different nameserver, use IP
+addresses instead of names, or make sure you use enough Kong nodes to still
+have all upstream services being used.
+
+- When the nameserver returns a `3 name error`, then that is a valid response
+for Kong. If this is unexpected, first validate the correct name is being
+queried for, and second check your nameserver configuration.
+
+- The initial pick of an IP address from a DNS record (A or SRV) is not
+randomized. So when using records with a `ttl` of 0, the nameserver is
+expected to randomize the record entries.
+
+[Back to TOC](#table-of-contents)
+
+### **Ring-balancer**
+
+When using the ring-balancer, the adding and removing of backend services will
+be handled by Kong, and no DNS updates will be necessary. Kong will act as the
+service registry. Nodes can be added/deleted with a single HTTP request and
+will instantly start/stop receiving traffic.
+
+Configuring the ring-balancer is done through the `upstream` and `target`
+entities.
+
+  - `target`: an IP address or hostname with a port number where a backend
+    service resides, eg. "192.168.100.12:80". Each target gets an additional
+    `weight` to indicate the relative load it gets. IP addresses can be
+    in both IPv4 and IPv6 format.
+  - `upstream`: a 'virtual hostname' which can be used in a Route `host`
+    field, e.g., an upstream named `weather.v2.service` would get all requests
+    from a Service with `host=weather.v2.service`.
+
+[Back to TOC](#table-of-contents)
+
+#### **Upstream**
+
+Each upstream gets its own ring-balancer. Each `upstream` can have many
+`target` entries attached to it, and requests proxied to the 'virtual hostname'
+will be load balanced over the targets. A ring-balancer has a pre-defined
+number of slots, and based on the target weights the slots get assigned to the
+targets of the upstream.
+
+Adding and removing targets can be done with a simple HTTP request on the
+Admin API. This operation is relatively cheap. Changing the upstream
+itself is more expensive as the balancer will need to be rebuilt when the
+number of slots change for example.
+
+The only occurrence where the balancer will be rebuilt automatically is when
+the target history is cleaned; other than that, it will only rebuild upon changes.
+
+Within the balancer there are the positions (from 1 to `slots`),
+which are __randomly distributed__ on the ring.
+The randomness is required to make invoking the ring-balancer cheap at
+runtime. A simple round-robin over the wheel (the positions) will do to
+provide a well distributed weighted round-robin over the `targets`, whilst
+also having cheap operations when inserting/deleting targets.
+
+The number of slots to use per target should (at least) be around 100 to make
+sure the slots are properly distributed. Eg. for an expected maximum of 8
+targets, the `upstream` should be defined with at least `slots=800`, even if
+the initial setup only features 2 targets.
+
+The tradeoff here is that the higher the number of slots, the better the random
+distribution, but the more expensive the changes are (add/removing targets)
+
+Detailed information on adding and manipulating
+upstreams is available in the `upstream` section of the
+[Admin API reference][upstream-object-reference].
+
+[Back to TOC](#table-of-contents)
+
+#### **Target**
+
+Because the `upstream` maintains a history of changes, targets can only be
+added, not modified nor deleted. To change a target, just add a new entry for
+the target, and change the `weight` value. The last entry is the one that will
+be used. As such setting `weight=0` will disable a target, effectively
+deleting it from the balancer. Detailed information on adding and manipulating
+targets is available in the `target` section of the
+[Admin API reference][target-object-reference].
+
+The targets will be automatically cleaned when there are 10x more inactive
+entries than active ones. Cleaning will involve rebuilding the balancer, and
+hence is more expensive than just adding a target entry.
+
+A `target` can also have a hostname instead of an IP address. In that case
+the name will be resolved and all entries found will individually be added to
+the ring balancer, e.g., adding `api.host.com:123` with `weight=100`. The
+name 'api.host.com' resolves to an A record with 2 IP addresses. Then both
+ip addresses will be added as target, each getting `weight=100` and port 123.
+__NOTE__: the weight is used for the individual entries, not for the whole!
+
+Would it resolve to an SRV record, then also the `port` and `weight` fields
+from the DNS record would be picked up, and would overrule the given port `123`
+and `weight=100`.
+
+The balancer will honor the DNS record's `ttl` setting and requery and update
+the balancer when it expires.
+
+__Exception__: When a DNS record has `ttl=0`, the hostname will be added
+as a single target, with the specified weight. Upon every proxied request
+to this target it will query the nameserver again.
+
+[Back to TOC](#table-of-contents)
+
+#### **Balancing algorithms**
+
+By default a ring-balancer will use a weighted-round-robin scheme. The alternative
+would be to use the hash-based algorithm. The input for the hash can be either
+`none`, `consumer`, `ip`, or `header`. When set to `none` the
+weighted-round-robin scheme will be used, and hashing will be disabled.
+
+There are two options, a primary and a fallback in case the primary fails
+(e.g., if the primary is set to `consumer`, but no consumer is authenticated)
+
+The different hashing options:
+
+- `none`: Do not use hashing, but use weighted-round-robin instead (default).
+
+- `consumer`: Use the consumer id as the hash input. This option will fallback
+  on the credential id if no consumer id is available (in case of external auth
+  like ldap).
+
+- `ip`: The remote (originating) IP address will be used as input. Review the
+  configuration settings for [determining the real IP][real-ip-config] when
+  using this.
+
+- `header`: use a specified header (in either `hash_on_header` or `hash_fallback_header`
+  field) as input for the hash.
+
+The hashing algorithm is based on 'consistent-hashing' (or the 'ketama principle')
+which makes sure that when the balancer gets modified by changing the targets
+(adding, removing, failing, or changing weights) only the minimum number of
+hashing losses occur. This will maximize upstream cache hits.
+
+For more information on the exact settings see the `upstream` section of the
+[Admin API reference][upstream-object-reference].
+
+[Back to TOC](#table-of-contents)
+
+#### **Balancing caveats**
+
+The ring-balancer is designed to work both with a single node as well as in a cluster.
+For the weighted-round-robin algorithm there isn't much difference, but when using
+the hash based algorithm it is important that all nodes build the exact same
+ring-balancer to make sure they all work identical. To do this the balancer
+must be build in a deterministic way.
+
+- Do not use hostnames in the balancer as the
+balancers might/will slowly diverge because the DNS ttl has only second precision
+and renewal is determined by when a name is actually requested. On top of this is
+the issue with some nameservers not returning all entries, which exacerbates
+this problem. So when using the hashing approach in a Kong cluster, add `target`
+entities only by their IP address, and never by name.
+
+- When picking your hash input make sure the input has enough variance to get
+to a well distributed hash. Hashes will be calculated using the CRC-32 digest.
+So for example, if your system has thousands of users, but only a few consumers, defined
+per platform (eg. 3 consumers: Web, iOS and Android) then picking the `consumer`
+hash input will not suffice, using the remote IP address by setting the hash to
+`ip` would provide more variance in the input and hence a better distribution
+in the hash output.
+
+[Back to TOC](#table-of-contents)
+
+### **Blue-Green Deployments**
+
+Using the ring-balancer a [blue-green deployment][blue-green-canary] can be easily orchestrated for
+a Service. Switching target infrastructure only requires a `PATCH` request on a
+Service, to change its `host` value.
+
+Set up the "Blue" environment, running version 1 of the address service:
+
+```bash
+# create an upstream
+$ curl -X POST http://kong:8001/upstreams \
+    --data "name=address.v1.service"
+
+# add two targets to the upstream
+$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+    --data "target=192.168.34.15:80"
+    --data "weight=100"
+$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+    --data "target=192.168.34.16:80"
+    --data "weight=50"
+
+# create a Service targeting the Blue upstream
+$ curl -X POST http://kong:8001/services/ \
+    --data "name=address-service" \
+    --data "host=address.v1.service" \
+    --data "path=/address"
+
+# finally, add a Route as an entry-point into the Service
+$ curl -X POST http://kong:8001/services/address-service/routes/ \
+    --data "hosts[]=address.mydomain.com"
+```
+
+Requests with host header set to `address.mydomain.com` will now be proxied
+by Kong to the two defined targets; 2/3 of the requests will go to
+`http://192.168.34.15:80/address` (`weight=100`), and 1/3 will go to
+`http://192.168.34.16:80/address` (`weight=50`).
+
+Before deploying version 2 of the address service, set up the "Green"
+environment:
+
+```bash
+# create a new Green upstream for address service v2
+$ curl -X POST http://kong:8001/upstreams \
+    --data "name=address.v2.service"
+
+# add targets to the upstream
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=100"
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=100"
+```
+
+To activate the Blue/Green switch, we now only need to update the Service:
+
+```bash
+# Switch the Service from Blue to Green upstream, v1 -> v2
+$ curl -X PATCH http://kong:8001/services/address-service \
+    --data "host=address.v2.service"
+```
+
+Incoming requests with host header set to `address.mydomain.com` will now be
+proxied by Kong to the new targets; 1/2 of the requests will go to
+`http://192.168.34.17:80/address` (`weight=100`), and the other 1/2 will go to
+`http://192.168.34.18:80/address` (`weight=100`).
+
+As always, the changes through the Kong Admin API are dynamic and will take
+effect immediately. No reload or restart is required, and no in progress
+requests will be dropped.
+
+[Back to TOC](#table-of-contents)
+
+### **Canary Releases**
+
+Using the ring-balancer, target weights can be adjusted granularly, allowing
+for a smooth, controlled [canary release][blue-green-canary].
+
+Using a very simple 2 target example:
+
+```bash
+# first target at 1000
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=1000"
+
+# second target at 0
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=0"
+```
+
+By repeating the requests, but altering the weights each time, traffic will
+slowly be routed towards the other target. For example, set it at 10%:
+
+```bash
+# first target at 900
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.17:80"
+    --data "weight=900"
+
+# second target at 100
+$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+    --data "target=192.168.34.18:80"
+    --data "weight=100"
+```
+
+The changes through the Kong Admin API are dynamic and will take
+effect immediately. No reload or restart is required, and no in progress
+requests will be dropped.
+
+[Back to TOC](#table-of-contents)
+
+[upstream-object-reference]: /docs/{{page.kong_version}}/admin-api#upstream-object
+[target-object-reference]: /docs/{{page.kong_version}}/admin-api#target-object
+[dns-order-config]: /docs/{{page.kong_version}}/configuration/#dns_order
+[real-ip-config]: /docs/{{page.kong_version}}/configuration/#real_ip_header
+[blue-green-canary]: http://blog.christianposta.com/deploy/blue-green-deployments-a-b-testing-and-canary-releases/

--- a/app/docs/0.14.x/lua-reference/index.html
+++ b/app/docs/0.14.x/lua-reference/index.html
@@ -1,0 +1,121 @@
+---
+title: Lua Reference
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="modules/kong.dao">kong.dao</a></li>
+            <li><a href="modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+
+      <h2>Modules</h2>
+      <table class="module_list">
+        <tr>
+          <td class="name"><a href="modules/kong.dao">kong.dao</a></td>
+          <td class="summary">Operates over entities of a given type in a database table.</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></td>
+          <td class="summary">Salt the password
+ Password is salted with the credential's consumer_id (long enough, unique)</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></td>
+          <td class="summary">Add an entry to the ALF's <code>entries</code></td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></td>
+          <td class="summary">Timer handlers</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></td>
+          <td class="summary">Supported algorithms for signing tokens.</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.tools.responses">kong.tools.responses</a></td>
+          <td class="summary">Kong helper methods to send HTTP responses to clients.</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.tools.timestamp">kong.tools.timestamp</a></td>
+          <td class="summary">Module for timestamp support.</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/kong.tools.utils">kong.tools.utils</a></td>
+          <td class="summary">Module containing some general utility functions used in many places in Kong.</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="modules/spec.helpers">spec.helpers</a></td>
+          <td class="summary">Collection of utilities to help testing Kong features and plugins.</td>
+        </tr>
+      </table>
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.dao.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.dao.html
@@ -1,0 +1,447 @@
+---
+title: Lua Reference - kong.dao
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li>kong.dao</li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.dao</code></h1>
+<p>Operates over entities of a given type in a database table.</p>
+<p>An instance of this class is to be instanciated for each entity, and can interact
+ with the table representing the entity in the database.</p>
+
+<p> Instanciations of this class are managed by the DAO Factory.</p>
+
+<p> This class provides an abstraction for various databases (PostgreSQL, Cassandra)
+ and is responsible for propagating clustering events related to data invalidation,
+ as well as foreign constraints when the underlying database does not support them
+ (as with Cassandra).</p>
+
+
+<h3>Info:</h3>
+<ul>
+</ul>
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#DAO:count">DAO:count (tbl)</a></td>
+    <td class="summary">Count the number of rows.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:delete">DAO:delete (tbl)</a></td>
+    <td class="summary">Delete a row.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:find">DAO:find (tbl)</a></td>
+    <td class="summary">Find a row.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:find_all">DAO:find_all (tbl)</a></td>
+    <td class="summary">Find all rows.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:find_page">DAO:find_page (tbl, page_offset, page_size)</a></td>
+    <td class="summary">Find a paginated set of rows.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:insert">DAO:insert (tbl, options)</a></td>
+    <td class="summary">Insert a row.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:new">DAO:new (db, model_mt, schema, constraints)</a></td>
+    <td class="summary">Instanciate a DAO.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#DAO:update">DAO:update (tbl, filter_keys, options)</a></td>
+    <td class="summary">Update a row.</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="DAO:count">DAO:count</a></h4>
+  </dt>
+  <dd>
+    Count the number of rows.
+ Count the number of rows matching the given values.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          (optional) A table containing the fields and values to filter for.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><span class="type">number</span></span>
+        count The total count of rows matching the given filter, or total count of rows if no filter was given.
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:delete">DAO:delete</a></h4>
+  </dt>
+  <dd>
+    Delete a row.
+ Delete a row in table related to this instance. Also deletes all rows with a relashionship to the deleted row
+ (via foreign key relations). For SQL databases such as PostgreSQL, the underlying implementation
+ leverages "FOREIGN KEY" constraints, but for others such as Cassandra, such operations are executed
+ manually.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          A table containing the primary key field(s) for this row.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        row A table representing the deleted row
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:find">DAO:find</a></h4>
+  </dt>
+  <dd>
+    Find a row.
+ Find a row by its given, mandatory primary key. All other fields are ignored.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          A table containing the primary key field(s) for this row.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        row The row, or nil if none could be found.
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:find_all">DAO:find_all</a></h4>
+  </dt>
+  <dd>
+    Find all rows.
+ Find all rows in the table, eventually matching the values in the given fields.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          (optional) A table containing the fields and values to search for.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><span class="type">rows</span></span>
+        An array of rows.
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:find_page">DAO:find_page</a></h4>
+  </dt>
+  <dd>
+    Find a paginated set of rows.
+ Find a pginated set of rows eventually matching the values in the given fields.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          (optional) A table containing the fields and values to filter for.
+        </li>
+        <li>
+          <code class="parameter">page_offset</code>
+          Offset at which to resume pagination.
+        </li>
+        <li>
+          <code class="parameter">page_size</code>
+          Size of the page to retrieve (number of rows).
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        rows An array of rows.
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:insert">DAO:insert</a></h4>
+  </dt>
+  <dd>
+    Insert a row.
+ Insert a given Lua table as a row in the related table.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          Table to insert as a row.
+        </li>
+        <li>
+          <code class="parameter">options</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          Options to use for this insertion. (<code>ttl</code>: Time-to-live for this row, in seconds, <code>quiet</code>: does not send event)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        res A table representing the insert row (with fields created during the insertion).
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:new">DAO:new</a></h4>
+  </dt>
+  <dd>
+    Instanciate a DAO.
+ The DAO Factory is responsible for instanciating DAOs for each entity.
+ This method is only documented for clarity.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">db</code>
+          An instance of the underlying database object (<code>cassandra_db</code> or <code>postgres_db</code>)
+        </li>
+        <li>
+          <code class="parameter">model_mt</code>
+          The related model metatable. Such metatables contain, among other things, validation methods.
+        </li>
+        <li>
+          <code class="parameter">schema</code>
+          The schema of the entity for which this DAO is instanciated. The schema contains crucial informations about how to interact with the database (fields type, table name, etc...)
+        </li>
+        <li>
+          <code class="parameter">constraints</code>
+          A table of contraints built by the DAO Factory. Such constraints are mostly useful for databases without support for foreign keys. SQL databases handle those contraints natively.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        self
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="DAO:update">DAO:update</a></h4>
+  </dt>
+  <dd>
+    Update a row.
+ Update a row in the related table. Performe a partial update by default (only fields in <code>tbl</code> will)
+ be updated. If asked, can perform a "full" update, replacing the entire entity (assuming it is valid)
+ with the one specified in <code>tbl</code> at once.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">tbl</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          A table containing the new values for this row.
+        </li>
+        <li>
+          <code class="parameter">filter_keys</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          A table which must contain the primary key(s) to select the row to be updated.
+        </li>
+        <li>
+          <code class="parameter">options</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          Options to use for this update. (<code>full</code>: performs a full update of the entity, <code>quiet</code>: does not send event).
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        res A table representing the updated entity.
+      </li>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+        err If an error occured, a table describing the issue.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.plugins.basic-auth.crypto.html
@@ -1,0 +1,129 @@
+---
+title: Lua Reference - kong.plugins.basic-auth.crypto
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li>kong.plugins.basic-auth.crypto</li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.plugins.basic-auth.crypto</code></h1>
+<p>Salt the password
+ Password is salted with the credential's consumer_id (long enough, unique)</p>
+<p></p>
+
+
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#encrypt">encrypt (credential)</a></td>
+    <td class="summary">Encrypt the password field credential table</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="encrypt">encrypt</a></h4>
+  </dt>
+  <dd>
+    Encrypt the password field credential table
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">credential</code>
+          The basic auth credential table
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        hash of the salted credential's password
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.plugins.galileo.alf.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.plugins.galileo.alf.html
@@ -1,0 +1,153 @@
+---
+title: Lua Reference - kong.plugins.galileo.alf
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li>kong.plugins.galileo.alf</li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.plugins.galileo.alf</code></h1>
+<p>Add an entry to the ALF's <code>entries</code></p>
+<p></p>
+
+
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#reset">reset ()</a></td>
+    <td class="summary">Empty the ALF</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#serialize">serialize (service_token, environment)</a></td>
+    <td class="summary">Encode the current ALF to JSON</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="reset">reset</a></h4>
+  </dt>
+  <dd>
+    Empty the ALF
+
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="serialize">serialize</a></h4>
+  </dt>
+  <dd>
+    Encode the current ALF to JSON
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">service_token</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
+          The ALF <code>serviceToken</code>
+        </li>
+        <li>
+          <code class="parameter">environment</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
+          (optional) The ALF <code>environment</code>
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
+        The ALF, JSON encoded
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.plugins.galileo.buffer.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.plugins.galileo.buffer.html
@@ -1,0 +1,122 @@
+---
+title: Lua Reference - kong.plugins.galileo.buffer
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li>kong.plugins.galileo.buffer</li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.plugins.galileo.buffer</code></h1>
+<p>Timer handlers</p>
+<p></p>
+
+
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#new">new (conf)</a></td>
+    <td class="summary">Buffer</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="new">new</a></h4>
+  </dt>
+  <dd>
+    Buffer
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">conf</code>
+
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.plugins.jwt.jwt_parser.html
@@ -1,0 +1,204 @@
+---
+title: Lua Reference - kong.plugins.jwt.jwt_parser
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li>kong.plugins.jwt.jwt_parser</li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.plugins.jwt.jwt_parser</code></h1>
+<p>Supported algorithms for signing tokens.</p>
+<p></p>
+
+
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#new">new (token)</a></td>
+    <td class="summary">Instanciate a JWT parser
+ Parse a JWT and instanciate a JWT parser for further operations
+ Return errors instead of an instance if any encountered</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#verify_registered_claims">verify_registered_claims (claims_to_verify)</a></td>
+    <td class="summary">Verify registered claims (according to RFC 7519 Section 4.1)
+ Claims are verified by type and a check.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#verify_signature">verify_signature (key)</a></td>
+    <td class="summary">Verify a JWT signature
+ Verify the current JWT signature against a given key</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="new">new</a></h4>
+  </dt>
+  <dd>
+    Instanciate a JWT parser
+ Parse a JWT and instanciate a JWT parser for further operations
+ Return errors instead of an instance if any encountered
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">token</code>
+          JWT to parse
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        JWT parser
+      </li>
+      <li>
+        error if any
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="verify_registered_claims">verify_registered_claims</a></h4>
+  </dt>
+  <dd>
+    Verify registered claims (according to RFC 7519 Section 4.1)
+ Claims are verified by type and a check.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">claims_to_verify</code>
+          A list of claims to verify.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        A boolean indicating true if no errors zere found
+      </li>
+      <li>
+        A list of errors
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="verify_signature">verify_signature</a></h4>
+  </dt>
+  <dd>
+    Verify a JWT signature
+ Verify the current JWT signature against a given key
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">key</code>
+          Key against which to verify the signature
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        A boolean indicating if the signature if verified or not
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.tools.responses.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.tools.responses.html
@@ -1,0 +1,257 @@
+---
+title: Lua Reference - kong.tools.responses
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li>kong.tools.responses</li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.tools.responses</code></h1>
+<p>Kong helper methods to send HTTP responses to clients.</p>
+<p>Can be used in the proxy (core/resolver), plugins or Admin API.
+ Most used HTTP status codes and responses are implemented as helper methods.</p>
+
+<h3>Usage:</h3>
+<ul>
+  <li><pre>local responses = require &quot;kong.tools.responses&quot;
+
+-- In an Admin API endpoint handler, or in one of the plugins&apos; phases.
+-- the `return` keyword is optional since the execution will be stopped
+-- anyways. It simply improves code readability.
+return responses.send_HTTP_OK()
+
+-- Or:
+return responses.send_HTTP_NOT_FOUND(&quot;No entity for given id&quot;)
+
+-- Raw send() helper:
+return responses.send(418, &quot;This is a teapot&quot;)
+</pre></li>
+</ul>
+
+<h3>Info:</h3>
+<ul>
+</ul>
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#send">send (status_code, body, headers)</a></td>
+    <td class="summary">Send a response with any status code or body,
+ Not all status codes are available as sugar methods, this function can be
+ used to send any response.</td>
+  </tr>
+</table>
+<h2><a href="#Tables">Tables</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#status_codes">status_codes</a></td>
+    <td class="summary">Define the most common HTTP status codes for sugar methods.</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="send">send</a></h4>
+  </dt>
+  <dd>
+    Send a response with any status code or body,
+ Not all status codes are available as sugar methods, this function can be
+ used to send any response.
+ For <code>status_code=5xx</code> the <code>content</code> parameter should be the description of the error that occurred.
+ For <code>status_code=500</code> the content will be logged by ngx.log as an ERR.
+ Will call <a href="https://github.com/openresty/lua-nginx-module#ngxsay">ngx.say</a> and <a href="https://github.com/openresty/lua-nginx-module#ngxexit">ngx.exit</a>, terminating the current context.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">status_code</code>
+          <span class="types"><span class="type">number</span></span>
+          HTTP status code to send
+        </li>
+        <li>
+          <code class="parameter">body</code>
+          A string or table which will be the body of the sent response. If table, the response will be encoded as a JSON object. If string, the response will be a JSON object and the string will be contained in the <code>message</code> property.
+        </li>
+        <li>
+          <code class="parameter">headers</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          Response headers to send.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        ngx.exit (Exit current context)
+      </li>
+    </ul>
+
+
+    <h5>See also:</h5>
+    <ul>
+      <li><a href="https://github.com/openresty/lua-nginx-module#ngxsay">ngx.say</a></li>
+      <li><a href="https://github.com/openresty/lua-nginx-module#ngxexit">ngx.exit</a></li>
+    </ul>
+
+
+
+  </dd>
+</dl>
+
+<h2 class="section-header "><a name="Tables">Tables</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="status_codes">status_codes</a></h4>
+  </dt>
+  <dd>
+    Define the most common HTTP status codes for sugar methods.
+ Each of those status will generate a helper method (sugar)
+ attached to this exported module prefixed with <code>send_</code>.
+ Final signature of those methods will be <code>send_&lt;status_code_key&gt;(message, headers)</code>. See <a href="../modules/kong.tools.responses.html#send">send</a> for more details on those parameters.
+
+    <h5>Fields:</h5>
+    <ul>
+        <li>
+          <code class="parameter">HTTP_OK</code>
+          200 OK
+        </li>
+        <li>
+          <code class="parameter">HTTP_CREATED</code>
+          201 Created
+        </li>
+        <li>
+          <code class="parameter">HTTP_NO_CONTENT</code>
+          204 No Content
+        </li>
+        <li>
+          <code class="parameter">HTTP_BAD_REQUEST</code>
+          400 Bad Request
+        </li>
+        <li>
+          <code class="parameter">HTTP_UNAUTHORIZED</code>
+          401 Unauthorized
+        </li>
+        <li>
+          <code class="parameter">HTTP_FORBIDDEN</code>
+          403 Forbidden
+        </li>
+        <li>
+          <code class="parameter">HTTP_NOT_FOUND</code>
+          404 Not Found
+        </li>
+        <li>
+          <code class="parameter">HTTP_METHOD_NOT_ALLOWED</code>
+          405 Method Not Allowed
+        </li>
+        <li>
+          <code class="parameter">HTTP_CONFLICT</code>
+          409 Conflict
+        </li>
+        <li>
+          <code class="parameter">HTTP_UNSUPPORTED_MEDIA_TYPE</code>
+          415 Unsupported Media Type
+        </li>
+        <li>
+          <code class="parameter">HTTP_INTERNAL_SERVER_ERROR</code>
+          Internal Server Error
+        </li>
+        <li>
+          <code class="parameter">HTTP_SERVICE_UNAVAILABLE</code>
+          503 Service Unavailable
+        </li>
+    </ul>
+
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">return</span> responses.send_HTTP_OK()</pre></li>
+      <li><pre class="example"><span class="keyword">return</span> responses.HTTP_CREATED(<span class="string">"Entity created"</span>)</pre></li>
+      <li><pre class="example"><span class="keyword">return</span> responses.HTTP_INTERNAL_SERVER_ERROR()</pre></li>
+    </ul>
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.tools.timestamp.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.tools.timestamp.html
@@ -1,0 +1,91 @@
+---
+title: Lua Reference - kong.tools.timestamp
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li>kong.tools.timestamp</li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.tools.timestamp</code></h1>
+<p>Module for timestamp support.</p>
+<p>Based on the LuaTZ module.</p>
+
+
+<h3>Info:</h3>
+<ul>
+</ul>
+
+
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/kong.tools.utils.html
+++ b/app/docs/0.14.x/lua-reference/modules/kong.tools.utils.html
@@ -1,0 +1,842 @@
+---
+title: Lua Reference - kong.tools.utils
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li>kong.tools.utils</li>
+            <li><a href="../../modules/spec.helpers">spec.helpers</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>kong.tools.utils</code></h1>
+<p>Module containing some general utility functions used in many places in Kong.</p>
+<p>NOTE: Before implementing a function here, consider if it will be used in many places
+ across Kong. If not, a local function in the appropriate module is prefered.</p>
+
+
+<h3>Info:</h3>
+<ul>
+</ul>
+
+<h2><a href="#Functions">Functions</a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#add_error">add_error (errors, k, v)</a></td>
+    <td class="summary">Add an error message to a key/value table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#check_hostname">check_hostname (address)</a></td>
+    <td class="summary">parses and validates a hostname.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#check_https">check_https (trusted_ip, allow_terminated)</a></td>
+    <td class="summary">Checks whether a request is https or was originally https (but already
+ terminated).</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#concat">concat (...)</a></td>
+    <td class="summary">Concatenates lists into a new table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#deep_copy">deep_copy (orig)</a></td>
+    <td class="summary">Deep copies a table into a new table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#encode_args">encode_args (args, raw)</a></td>
+    <td class="summary">Encode a Lua table to a querystring
+ Tries to mimic ngx_lua's <code>ngx.encode_args</code>, but also percent-encode querystring values.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#format_host">format_host (p1, p2)</a></td>
+    <td class="summary">Formats an ip address or hostname with an (optional) port for use in urls.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#get_hostname">get_hostname ()</a></td>
+    <td class="summary">Retrieves the hostname of the local machine</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#hostname_type">hostname_type (name)</a></td>
+    <td class="summary">checks the hostname type; ipv4, ipv6, or name.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#is_array">is_array (t)</a></td>
+    <td class="summary">Checks if a table is an array and not an associative array.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#load_module_if_exists">load_module_if_exists (module_name)</a></td>
+    <td class="summary">Try to load a module.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#normalize_ip">normalize_ip (address)</a></td>
+    <td class="summary">verifies and normalizes ip adresses and hostnames.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#normalize_ipv4">normalize_ipv4 (address)</a></td>
+    <td class="summary">parses, validates and normalizes an ipv4 address.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#normalize_ipv6">normalize_ipv6 (address)</a></td>
+    <td class="summary">parses, validates and normalizes an ipv6 address.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#pack">pack (...)</a></td>
+    <td class="summary">packs a set of arguments in a table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#shallow_copy">shallow_copy (orig)</a></td>
+    <td class="summary">Copies a table into a new table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#split">split ()</a></td>
+    <td class="summary">splits a string.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#strip">strip ()</a></td>
+    <td class="summary">strips whitespace from a string.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#table_contains">table_contains (arr, val)</a></td>
+    <td class="summary">Checks if a value exists in a table.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#table_merge">table_merge (t1, t2)</a></td>
+    <td class="summary">Merges two table together.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#unpack">unpack (t, i, j)</a></td>
+    <td class="summary">unpacks a table to a list of arguments.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#uuid">uuid ()</a></td>
+    <td class="summary">Generates a v4 uuid.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#validate_header_name">validate_header_name (name)</a></td>
+    <td class="summary">Validates a header name.</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header "><a name="Functions">Functions</a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="add_error">add_error</a></h4>
+  </dt>
+  <dd>
+    Add an error message to a key/value table.
+ If the key already exists, a sub table is created with the original and the new value.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">errors</code>
+          (Optional) Table to attach the error to. If <code>nil</code>, the table will be created.
+        </li>
+        <li>
+          <code class="parameter">k</code>
+          Key on which to insert the error in the <code>errors</code> table.
+        </li>
+        <li>
+          <code class="parameter">v</code>
+          Value of the error
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        The <code>errors</code> table with the new error inserted.
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="check_hostname">check_hostname</a></h4>
+  </dt>
+  <dd>
+    parses and validates a hostname.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">address</code>
+          the string containing the hostname (formats; name, name:port)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        hostname (string) + port (number or nil), or alternatively nil+error
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="check_https">check_https</a></h4>
+  </dt>
+  <dd>
+    Checks whether a request is https or was originally https (but already
+ terminated).  It will check in the current request (global <code>ngx</code> table). If
+ the header <code>X-Forwarded-Proto</code> exists -- with value <code>https</code> then it will also
+ be considered as an https connection.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">trusted_ip</code>
+          boolean indicating if the client is a trusted IP
+        </li>
+        <li>
+          <code class="parameter">allow_terminated</code>
+          if truthy, the <code>X-Forwarded-Proto</code> header will be checked as well.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        boolean or nil+error in case the header exists multiple times
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="concat">concat</a></h4>
+  </dt>
+  <dd>
+    Concatenates lists into a new table.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">...</code>
+
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="deep_copy">deep_copy</a></h4>
+  </dt>
+  <dd>
+    Deep copies a table into a new table.
+ Tables used as keys are also deep copied, as are metatables
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">orig</code>
+          The table to copy
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        Returns a copy of the input table
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="encode_args">encode_args</a></h4>
+  </dt>
+  <dd>
+    Encode a Lua table to a querystring
+ Tries to mimic ngx_lua's <code>ngx.encode_args</code>, but also percent-encode querystring values.
+ Supports multi-value query args, boolean values.
+ It also supports encoding for bodies (only because it is used in http_client for specs.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">args</code>
+          <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.5">table</a></span>
+          A key/value table containing the query args to encode.
+        </li>
+        <li>
+          <code class="parameter">raw</code>
+          <span class="types"><span class="type">boolean</span></span>
+          If true, will not percent-encode any key/value and will ignore special boolean rules.
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
+        A valid querystring (without the prefixing '?')
+      </li>
+    </ul>
+
+
+    <h5>See also:</h5>
+    <ul>
+    </ul>
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="format_host">format_host</a></h4>
+  </dt>
+  <dd>
+    Formats an ip address or hostname with an (optional) port for use in urls.
+ Supports ipv4, ipv6 and names.</p>
+
+<p> Explictly accepts 'nil+error' as input, to pass through any errors from the normalizing and name checking functions.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">p1</code>
+          address to format, either string with name/ip, table returned from <a href="../modules/kong.tools.utils.html#normalize_ip">normalize_ip</a>, or from the <code>socket.url</code> library.
+        </li>
+        <li>
+          <code class="parameter">p2</code>
+          port (optional) if p1 is a table, then this port will be inserted if no port-field is in the table
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        formatted address or nil+error
+      </li>
+    </ul>
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> addr, err = format_ip(normalize_ip(<span class="string">"001.002.003.004:123"</span>))  <span class="comment">--&gt; "1.2.3.4:123"
+</span><span class="keyword">local</span> addr, err = format_ip(normalize_ip(<span class="string">"::1"</span>))                  <span class="comment">--&gt; "[0000:0000:0000:0000:0000:0000:0000:0001]"
+</span><span class="keyword">local</span> addr, err = format_ip(<span class="string">"::1"</span>, <span class="number">80</span>))                           <span class="comment">--&gt; "[::1]:80"
+</span><span class="keyword">local</span> addr, err = format_ip(check_hostname(<span class="string">"//bad .. name\\"))    --&gt; nil, "</span>invalid hostname: ... "</pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="get_hostname">get_hostname</a></h4>
+  </dt>
+  <dd>
+    Retrieves the hostname of the local machine
+
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        string  The hostname
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="hostname_type">hostname_type</a></h4>
+  </dt>
+  <dd>
+    checks the hostname type; ipv4, ipv6, or name.
+ Type is determined by exclusion, not by validation. So if it returns 'ipv6' then
+ it can only be an ipv6, but it is not necessarily a valid ipv6 address.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">name</code>
+          the string to check (this may contain a portnumber)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        string either; 'ipv4', 'ipv6', or 'name'
+      </li>
+    </ul>
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example">hostname_type(<span class="string">"123.123.123.123"</span>)  <span class="comment">--&gt;  "ipv4"
+</span>hostname_type(<span class="string">"::1"</span>)              <span class="comment">--&gt;  "ipv6"
+</span>hostname_type(<span class="string">"some::thing"</span>)      <span class="comment">--&gt;  "ipv6", but invalid...</span></pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="is_array">is_array</a></h4>
+  </dt>
+  <dd>
+    Checks if a table is an array and not an associative array.
+ <strong>* NOTE *</strong> string-keys containing integers are considered valid array entries!
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">t</code>
+          The table to check
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        Returns <code>true</code> if the table is an array, <code>false</code> otherwise
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="load_module_if_exists">load_module_if_exists</a></h4>
+  </dt>
+  <dd>
+    Try to load a module.
+ Will not throw an error if the module was not found, but will throw an error if the
+ loading failed for another reason (eg: syntax error).
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">module_name</code>
+          Path of the module to load (ex: kong.plugins.keyauth.api).
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        success A boolean indicating wether the module was found.
+      </li>
+      <li>
+        module The retrieved module, or the error in case of a failure
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="normalize_ip">normalize_ip</a></h4>
+  </dt>
+  <dd>
+    verifies and normalizes ip adresses and hostnames.  Supports ipv4, ipv4:port, ipv6, [ipv6]:port, name, name:port.
+ Returned ipv4 addresses will have no leading zero's, ipv6 will be fully expanded without brackets.
+ Note: a name will not be normalized!
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">address</code>
+          string containing the address
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        table with the following fields: <code>host</code> (string; normalized address, or name), <a href="https://www.lua.org/manual/5.1/manual.html#pdf-type">type</a> (string; 'ipv4', 'ipv6', 'name'), and <code>port</code> (number or nil), or alternatively nil+error on invalid input
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="normalize_ipv4">normalize_ipv4</a></h4>
+  </dt>
+  <dd>
+    parses, validates and normalizes an ipv4 address.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">address</code>
+          the string containing the address (formats; ipv4, ipv4:port)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        normalized address (string) + port (number or nil), or alternatively nil+error
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="normalize_ipv6">normalize_ipv6</a></h4>
+  </dt>
+  <dd>
+    parses, validates and normalizes an ipv6 address.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">address</code>
+          the string containing the address (formats; ipv6, [ipv6], [ipv6]:port)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        normalized expanded address (string) + port (number or nil), or alternatively nil+error
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="pack">pack</a></h4>
+  </dt>
+  <dd>
+    packs a set of arguments in a table.
+ Explicitly sets field <code>n</code> to the number of arguments, so it is <code>nil</code> safe
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">...</code>
+
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="shallow_copy">shallow_copy</a></h4>
+  </dt>
+  <dd>
+    Copies a table into a new table.
+ neither sub tables nor metatables will be copied.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">orig</code>
+          The table to copy
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        Returns a copy of the input table
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="split">split</a></h4>
+  </dt>
+  <dd>
+    splits a string.
+ just a placeholder to the penlight <code>pl.stringx.split</code> function
+
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="strip">strip</a></h4>
+  </dt>
+  <dd>
+    strips whitespace from a string.
+ just a placeholder to the penlight <code>pl.stringx.strip</code> function
+
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="table_contains">table_contains</a></h4>
+  </dt>
+  <dd>
+    Checks if a value exists in a table.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">arr</code>
+          The table to use
+        </li>
+        <li>
+          <code class="parameter">val</code>
+          The value to check
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        Returns <code>true</code> if the table contains the value, <code>false</code> otherwise
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="table_merge">table_merge</a></h4>
+  </dt>
+  <dd>
+    Merges two table together.
+ A new table is created with a non-recursive copy of the provided tables
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">t1</code>
+          The first table
+        </li>
+        <li>
+          <code class="parameter">t2</code>
+          The second table
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        The (new) merged table
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="unpack">unpack</a></h4>
+  </dt>
+  <dd>
+    unpacks a table to a list of arguments.
+ Explicitly honors the <code>n</code> field if given in the table, so it is <code>nil</code> safe
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">t</code>
+
+        </li>
+        <li>
+          <code class="parameter">i</code>
+
+        </li>
+        <li>
+          <code class="parameter">j</code>
+
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="uuid">uuid</a></h4>
+  </dt>
+  <dd>
+    Generates a v4 uuid.
+
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        string with uuid
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="validate_header_name">validate_header_name</a></h4>
+  </dt>
+  <dd>
+    Validates a header name.
+ Checks characters used in a header name to be valid, as per nginx only
+ a-z, A-Z, 0-9 and '-' are allowed.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">name</code>
+          (string) the header name to verify
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        the valid header name, or <code>nil+error</code>
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/lua-reference/modules/spec.helpers.html
+++ b/app/docs/0.14.x/lua-reference/modules/spec.helpers.html
@@ -1,0 +1,833 @@
+---
+title: Lua Reference - spec.helpers
+layout: default
+---
+
+
+<header class="page-header">
+  <div class="container">
+    <div class="page-header-icon">
+      <img src="/assets/images/icons/icn-documentation.svg" alt="Documentation" />
+    </div>
+    <div class="page-header-title">
+      <h1>Public Lua API Reference</h1>
+      <p>For plugins developers and core contributors</p>
+    </div>
+    {% if site.data.kong_versions.size > 1 %}
+      <div class="dropdown page-header-right">
+        <button class="page-header-btn" id="version-dropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Version {{page.kong_version}}
+          {% if page.kong_version == site.data.kong_latest.release %}<em>(latest)</em>{% endif %}
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="version-dropdown">
+          {% for ver in site.data.kong_versions %}
+            {% if page.kong_version != ver.release %}
+              <li>
+                {% if ver.lua_doc %}
+                  <a href="/docs/{{ver.release}}/lua-reference/"{% if ver.release == page.kong_version %} class="active"{% endif %}>
+                    {{ver.release}}
+                    {% if ver.release == site.data.kong_latest.release %}(latest){% endif %}
+                  </a>
+                {% else %}
+                  <span>Not available for {{ver.release}}</span>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+</header>
+
+<div class="container">
+  <aside class="page-navigation">
+    <nav>
+      <ul>
+        <li>
+          <a href="/docs/{{page.kong_version}}"><h5>Back to docs</h5></a>
+        </li>
+        <li>
+          <a href="/docs/{{page.kong_version}}/lua-reference/"><h5>Index</h5></a>
+        </li>
+        <li>
+          <h5>Modules</h5>
+          <ul>
+            <li><a href="../../modules/kong.dao">kong.dao</a></li>
+            <li><a href="../../modules/kong.plugins.basic-auth.crypto">kong.plugins.basic-auth.crypto</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.alf">kong.plugins.galileo.alf</a></li>
+            <li><a href="../../modules/kong.plugins.galileo.buffer">kong.plugins.galileo.buffer</a></li>
+            <li><a href="../../modules/kong.plugins.jwt.jwt_parser">kong.plugins.jwt.jwt_parser</a></li>
+            <li><a href="../../modules/kong.tools.responses">kong.tools.responses</a></li>
+            <li><a href="../../modules/kong.tools.timestamp">kong.tools.timestamp</a></li>
+            <li><a href="../../modules/kong.tools.utils">kong.tools.utils</a></li>
+            <li>spec.helpers</li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+
+  <div class="page-content-container">
+  <div class="page-content">
+    <div class="content">
+<h1><code>spec.helpers</code></h1>
+<p>Collection of utilities to help testing Kong features and plugins.</p>
+<p></p>
+
+
+<h3>Info:</h3>
+<ul>
+</ul>
+
+<h2><a href="#http_client">http_client </a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#admin_client">admin_client ()</a></td>
+    <td class="summary">returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong admin port.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#http_client">http_client (host, port, timeout)</a></td>
+    <td class="summary">Creates a http client.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#http_client:send">http_client:send (opts)</a></td>
+    <td class="summary">Send a http request.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#proxy_client">proxy_client ()</a></td>
+    <td class="summary">returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong proxy port.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#proxy_ssl_client">proxy_ssl_client ()</a></td>
+    <td class="summary">returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong SSL proxy port.</td>
+  </tr>
+</table>
+<h2><a href="#TCP_UDP_server_helpers">TCP/UDP server helpers </a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#http_server">http_server (port)</a></td>
+    <td class="summary">Starts a HTTP server.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#tcp_server">tcp_server (port)</a></td>
+    <td class="summary">Starts a TCP server.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#udp_server">udp_server (port)</a></td>
+    <td class="summary">Starts a UDP server.</td>
+  </tr>
+</table>
+<h2><a href="#Custom_assertions">Custom assertions </a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#contains">contains (expected, array, pattern)</a></td>
+    <td class="summary">Assertion to check whether a value lives in an array.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#fail">fail (...)</a></td>
+    <td class="summary">Generic fail assertion.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#formparam">formparam (name)</a></td>
+    <td class="summary">Adds an assertion to look for a urlencoded form parameter in a mockbin request.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#header">header (name)</a></td>
+    <td class="summary">Adds an assertion to look for a named header in a <code>headers</code> subtable.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#jsonbody">jsonbody ()</a></td>
+    <td class="summary">Checks and returns a json body of an http response/request.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#queryparam">queryparam (name)</a></td>
+    <td class="summary">An assertion to look for a query parameter in a <code>queryString</code> subtable.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#request">request (response)</a></td>
+    <td class="summary">Generic modifier "request".</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#response">response (response)</a></td>
+    <td class="summary">Generic modifier "response".</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#status">status (expected, response)</a></td>
+    <td class="summary">Assertion to check the statuscode of a http response.</td>
+  </tr>
+</table>
+<h2><a href="#Shell_helpers">Shell helpers </a></h2>
+<table class="function_list">
+  <tr>
+    <td class="name"><a href="#clean_prefix">clean_prefix (prefix)</a></td>
+    <td class="summary">Cleans the Kong environment.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#execute">execute (...)</a></td>
+    <td class="summary">Execute a command.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#kong_exec">kong_exec (cmd, env)</a></td>
+    <td class="summary">Execute a Kong command.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#prepare_prefix">prepare_prefix (prefix)</a></td>
+    <td class="summary">Prepare the Kong environment.</td>
+  </tr>
+  <tr>
+    <td class="name"><a href="#wait_for_invalidation">wait_for_invalidation (key, timeout)</a></td>
+    <td class="summary">Waits for invalidation of a cached key by polling the mgt-api
+ and waiting for a 404 response.</td>
+  </tr>
+</table>
+
+
+<h2 class="section-header has-description"><a name="http_client">http_client </a></h2>
+
+<div class="section-description">
+An http-client class to perform requests.
+</div>
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="admin_client">admin_client</a></h4>
+  </dt>
+  <dd>
+    returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong admin port.
+
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="http_client">http_client</a></h4>
+  </dt>
+  <dd>
+    Creates a http client.  Based on https://github.com/pintsized/lua-resty-http
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">host</code>
+          hostname to connect to
+        </li>
+        <li>
+          <code class="parameter">port</code>
+          port to connect to
+        </li>
+        <li>
+          <code class="parameter">timeout</code>
+          in seconds
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        http client
+      </li>
+    </ul>
+
+
+    <h5>See also:</h5>
+    <ul>
+      <li><a href="../../modules/spec.helpers#http_client:send">http_client:send</a></li>
+    </ul>
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="http_client:send">http_client:send</a></h4>
+  </dt>
+  <dd>
+    Send a http request.  Based on https://github.com/pintsized/lua-resty-http.
+ If <code>opts.body</code> is a table and "Content-Type" header contains
+ <code>application/json</code>, <code>www-form-urlencoded</code>, or <code>multipart/form-data</code>, then it
+ will automatically encode the body according to the content type.
+ If <code>opts.query</code> is a table, a query string will be constructed from it and
+ appended
+ to the request path (assuming none is already present).
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">opts</code>
+          table with options. See https://github.com/pintsized/lua-resty-http
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="proxy_client">proxy_client</a></h4>
+  </dt>
+  <dd>
+    returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong proxy port.
+
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="proxy_ssl_client">proxy_ssl_client</a></h4>
+  </dt>
+  <dd>
+    returns a pre-configured <a href="../modules/spec.helpers.html#http_client">http_client</a> for the Kong SSL proxy port.
+
+
+
+
+
+
+
+  </dd>
+</dl>
+
+<h2 class="section-header "><a name="TCP_UDP_server_helpers">TCP/UDP server helpers </a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="http_server">http_server</a></h4>
+  </dt>
+  <dd>
+    Starts a HTTP server.
+ Accepts a single connection and then closes. Sends a 200 ok, 'Connection:
+ close' response.
+ If the request received has path <code>/delay</code> then the response will be delayed
+ by 2 seconds.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">port</code>
+          `    The port where the server will be listening to
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <code>thread</code> A thread object
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="tcp_server">tcp_server</a></h4>
+  </dt>
+  <dd>
+    Starts a TCP server.
+ Accepts a single connection and then closes, echoing what was received
+ (single read).
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">port</code>
+          `    The port where the server will be listening to
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <code>thread</code> A thread object
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="udp_server">udp_server</a></h4>
+  </dt>
+  <dd>
+    Starts a UDP server.
+ Accepts a single connection, reading once and then closes
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">port</code>
+          `    The port where the server will be listening to
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        <code>thread</code> A thread object
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+</dl>
+
+<h2 class="section-header "><a name="Custom_assertions">Custom assertions </a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="contains">contains</a></h4>
+  </dt>
+  <dd>
+    Assertion to check whether a value lives in an array.
+ pattern
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">expected</code>
+          The value to search for
+        </li>
+        <li>
+          <code class="parameter">array</code>
+          The array to search for the value
+        </li>
+        <li>
+          <code class="parameter">pattern</code>
+          (optional) If thruthy, then <code>expected</code> is matched as a string
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        the index at which the value was found
+      </li>
+    </ul>
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> arr = { <span class="string">"one"</span>, <span class="string">"three"</span> }
+<span class="keyword">local</span> i = <span class="global">assert</span>.contains(<span class="string">"one"</span>, arr)        <span class="comment">--&gt; passes; i == 1
+</span><span class="keyword">local</span> i = <span class="global">assert</span>.contains(<span class="string">"two"</span>, arr)        <span class="comment">--&gt; fails
+</span><span class="keyword">local</span> i = <span class="global">assert</span>.contains(<span class="string">"ee$"</span>, arr, <span class="keyword">true</span>)  <span class="comment">--&gt; passes; i == 2</span></pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="fail">fail</a></h4>
+  </dt>
+  <dd>
+    Generic fail assertion.  A convenience function for debugging tests, always
+ fails. It will output the values it was called with as a table, with an <code>n</code>
+ field to indicate the number of arguments received.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">...</code>
+          any set of parameters to be displayed with the failure
+        </li>
+    </ul>
+
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="global">assert</span>.fail(some, value)</pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="formparam">formparam</a></h4>
+  </dt>
+  <dd>
+    Adds an assertion to look for a urlencoded form parameter in a mockbin request.
+ Parameter name comparison is done case-insensitive. Use the <a href="../modules/spec.helpers.html#request">request</a> modifier to set
+ the request to operate on.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">name</code>
+          name of the form parameter to look up (case insensitive)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        value of the parameter
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="header">header</a></h4>
+  </dt>
+  <dd>
+    Adds an assertion to look for a named header in a <code>headers</code> subtable.
+ Header name comparison is done case-insensitive.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">name</code>
+          header name to look for (case insensitive).
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        value of the header
+      </li>
+    </ul>
+
+
+    <h5>See also:</h5>
+    <ul>
+      <li><a href="../../modules/spec.helpers#response">response</a></li>
+      <li><a href="../../modules/spec.helpers#request">request</a></li>
+    </ul>
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="jsonbody">jsonbody</a></h4>
+  </dt>
+  <dd>
+    Checks and returns a json body of an http response/request.  Only checks
+ validity of the json, does not check appropriate headers. Setting the target
+ to check can be done through <a href="../modules/spec.helpers.html#request">request</a> or <a href="../modules/spec.helpers.html#response">response</a> (requests are only
+ supported with mockbin.com).
+
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        the decoded json as a table
+      </li>
+    </ul>
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> res = <span class="global">assert</span>(client:send { .. your request params here .. })
+<span class="keyword">local</span> json_table = <span class="global">assert</span>.response(res).has.jsonbody()</pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="queryparam">queryparam</a></h4>
+  </dt>
+  <dd>
+    An assertion to look for a query parameter in a <code>queryString</code> subtable.
+ Parameter name comparison is done case-insensitive.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">name</code>
+          name of the query parameter to look up (case insensitive)
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        value of the parameter
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="request">request</a></h4>
+  </dt>
+  <dd>
+    Generic modifier "request".
+ Will set a "request" value in the assertion state, so following
+ assertions will operate on the value set.
+ The request must be inside a 'response' from mockbin.org or httpbin.org
+ be extracted from the response.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">response</code>
+          results from <a href="../modules/spec.helpers.html#http_client:send">http_client:send</a> function. The request will
+        </li>
+    </ul>
+
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> res = <span class="global">assert</span>(client:send { .. your request parameters here ..})
+<span class="keyword">local</span> length = <span class="global">assert</span>.request(res).has.header(<span class="string">"Content-Length"</span>)</pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="response">response</a></h4>
+  </dt>
+  <dd>
+    Generic modifier "response".
+ Will set a "response" value in the assertion state, so following
+ assertions will operate on the value set.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">response</code>
+          results from <a href="../modules/spec.helpers.html#http_client:send">http_client:send</a> function.
+        </li>
+    </ul>
+
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> res = <span class="global">assert</span>(client:send { .. your request parameters here ..})
+<span class="keyword">local</span> length = <span class="global">assert</span>.response(res).has.header(<span class="string">"Content-Length"</span>)</pre></li>
+    </ul>
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="status">status</a></h4>
+  </dt>
+  <dd>
+    Assertion to check the statuscode of a http response.
+ alternatively use <a href="../modules/spec.helpers.html#response">response</a>.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">expected</code>
+          the expected status code
+        </li>
+        <li>
+          <code class="parameter">response</code>
+          (optional) results from <a href="../modules/spec.helpers.html#http_client:send">http_client:send</a> function,
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        the response body as a string
+      </li>
+    </ul>
+
+
+
+    <h5>Usage:</h5>
+    <ul>
+      <li><pre class="example"><span class="keyword">local</span> res = <span class="global">assert</span>(client:send { .. your request params here .. })
+<span class="keyword">local</span> body = <span class="global">assert</span>.has.status(<span class="number">200</span>, res)             <span class="comment">-- or alternativly
+</span><span class="keyword">local</span> body = <span class="global">assert</span>.response(res).has.status(<span class="number">200</span>)    <span class="comment">-- does the same</span></pre></li>
+    </ul>
+
+
+  </dd>
+</dl>
+
+<h2 class="section-header "><a name="Shell_helpers">Shell helpers </a></h2>
+
+
+<dl class="function">
+  <hr />
+  <dt>
+    <h4><a name="clean_prefix">clean_prefix</a></h4>
+  </dt>
+  <dd>
+    Cleans the Kong environment.
+ Deletes the working directory if it exists.
+ configuration will be used
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">prefix</code>
+          (optional) path to the working directory, if omitted the test
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="execute">execute</a></h4>
+  </dt>
+  <dd>
+    Execute a command.
+ Modified version of <code>pl.utils.executeex()</code> so the output can directly be
+ used on an assertion.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">...</code>
+          see penlight documentation
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        ok, stderr, stdout; stdout is only included when the result was ok
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="kong_exec">kong_exec</a></h4>
+  </dt>
+  <dd>
+    Execute a Kong command.
+ variables, overriding the test config (each key will automatically be
+ prefixed with <code>KONG_</code> and be converted to uppercase)
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">cmd</code>
+          Kong command to execute, eg. <code>start</code>, <code>stop</code>, etc.
+        </li>
+        <li>
+          <code class="parameter">env</code>
+          (optional) table with kong parameters to set as environment
+        </li>
+    </ul>
+
+    <h5>Returns:</h5>
+    <ul>
+      <li>
+        same output as <code>exec</code>
+      </li>
+    </ul>
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="prepare_prefix">prepare_prefix</a></h4>
+  </dt>
+  <dd>
+    Prepare the Kong environment.
+ creates the workdirectory and deletes any existing one.
+ configuration will be used
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">prefix</code>
+          (optional) path to the working directory, if omitted the test
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+  <hr />
+  <dt>
+    <h4><a name="wait_for_invalidation">wait_for_invalidation</a></h4>
+  </dt>
+  <dd>
+    Waits for invalidation of a cached key by polling the mgt-api
+ and waiting for a 404 response.
+
+    <h5>Parameters:</h5>
+    <ul>
+        <li>
+          <code class="parameter">key</code>
+          the cache-key to check
+        </li>
+        <li>
+          <code class="parameter">timeout</code>
+          (optional) in seconds, defaults to 10.
+        </li>
+    </ul>
+
+
+
+
+
+
+  </dd>
+</dl>
+
+
+    </div>
+  </div>
+</div>
+</div>

--- a/app/docs/0.14.x/network.md
+++ b/app/docs/0.14.x/network.md
@@ -1,0 +1,46 @@
+---
+title: Network & Firewall
+---
+
+# Network & Firewall
+
+In this section you will find a summary about the recommended network and firewall settings for Kong.
+
+## Ports
+
+Kong uses multiple connections for different purposes.
+
+* proxy 
+* management api
+
+
+### Proxy
+
+The proxy ports is where Kong receives its incoming traffic. There are two ports with the following defaults;
+
+* `8000` for proxying. This is where Kong listens for HTTP traffic. Be sure to change it to `80` once you go to production. See [proxy_listen].
+* `8443` for proxying HTTPS traffic. Be sure to change it to `443` once you go to production. See [proxy_listen] and the `ssl` suffix.
+
+These are the **only ports** that should be made available to your clients.
+
+### Management api
+
+This is the port where Kong exposes its management api. Hence in production this port should be firewalled to protect
+it from unauthorized access.
+
+* `8001` provides Kong's **Admin API** that you can use to operate Kong. See [admin_listen].
+* `8444` provides the same Kong **Admin API** but using HTTPS. See [admin_listen] and the `ssl` suffix.
+
+## Firewall
+
+Below are the recommended firewall settings:
+
+* The upstream APIs behind Kong will be available via the [proxy_listen] interface/port values.
+  Configure these values according to the access level you wish to grant to the upstream APIs.
+* If you are binding the Admin API to a public-facing interface (via [admin_listen]), then **protect** it to only allow trusted clients to access the Admin API.
+  See also [Securing the Admin API][secure_admin_api].
+
+
+[proxy_listen]: /docs/{{page.kong_version}}/configuration/#proxy_listen
+[admin_listen]: /docs/{{page.kong_version}}/configuration/#admin_listen
+[secure_admin_api]: /docs/{{page.kong_version}}/secure-admin-api

--- a/app/docs/0.14.x/plugin-development/access-the-datastore.md
+++ b/app/docs/0.14.x/plugin-development/access-the-datastore.md
@@ -1,0 +1,67 @@
+---
+title: Plugin Development - Accessing the datastore
+book: plugin_dev
+chapter: 5
+---
+
+# {{page.title}}
+
+Kong interacts with the model layer through classes we refer to as "DAOs". This chapter will detail the available API to interact with the datastore.
+
+Kong supports two primary datastores: [Cassandra {{site.data.kong_latest.dependencies.cassandra}}](http://cassandra.apache.org/) and [PostgreSQL {{site.data.kong_latest.dependencies.postgres}}](http://www.postgresql.org/).
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> As of 0.13.0, Kong is rolling out a new version of the DAO abstraction layer called `singletons.db`, which will gradually replace `singletons.dao`
+</div>
+---
+
+### `singletons.db` and `singletons.dao`
+
+All entities in Kong are represented by:
+
+- A schema that describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints etc... This schema is a table described in the [plugin configuration]({{page.book.chapters.plugin-configuration}}) chapter.
+- An instance of the `DAO` class mapping to the database currently in use (Cassandra or PostgreSQL). This class' methods consume the schema and expose methods to insert, update, find and delete entities of that type.
+
+The core entities in Kong are: Services, Routes, Consumers and Plugins. Services and Routes are available through the new `singletons.db` variable. The rest of the entities are available through `singletons.dao`. In the future they will be gradually migrated to `singletons.db`.
+
+Each of these entities can be interacted with through their corresponding DAO instance, available through the **DAO Factory** instance. The DAO Factory is responsible for loading these core entities' DAOs as well as any additional entities, provided for example by plugins.
+
+Both the DAO Factory and the new `db` interface are singleton instances in Kong and thus, are accessible through the `singletons` module:
+
+```lua
+local singletons = require "kong.singletons"
+
+-- Core DAOs
+local services_dao = singletons.db.services
+local routes_dao = singletons.db.routes
+local consumers_dao = singletons.dao.consumers
+local plugins_dao = singletons.dao.plugins
+```
+
+---
+
+### The DAO Lua API
+
+The DAO class is responsible for the operations executed on a given table in the datastore, generally mapping to an entity in Kong. All the underlying supported databases (currently Cassandra and PostgreSQL) comply to the same interface, thus making the DAO compatible with all of them.
+
+For example, inserting a Service (with `singletons.db`) and a Plugin (with `singletons.dao`) is as easy as:
+
+```lua
+local singletons = require "kong.singletons"
+local db  = singletons.db
+local dao = singletons.dao
+
+local inserted_service, err = db.services:insert({
+  name = "mockbin",
+  url = "http://mockbin.org"
+})
+
+local inserted_plugin, err = dao.plugins:insert({
+  name = "key-auth",
+  service_id = inserted_service.id
+})
+```
+
+---
+
+Next: [Custom Entities &rsaquo;]({{page.book.next}})

--- a/app/docs/0.14.x/plugin-development/admin-api.md
+++ b/app/docs/0.14.x/plugin-development/admin-api.md
@@ -1,0 +1,104 @@
+---
+title: Plugin Development - Extending the Admin API
+book: plugin_dev
+chapter: 8
+---
+
+# {{page.title}}
+
+#### Module
+
+```
+"kong.plugins.<plugin_name>.api"
+```
+
+---
+
+The [Admin API] is the interface through which users will configure Kong. If your plugin has custom entities or management requirements, then you will need to extend the Admin API. This allows you to expose your own endpoints and implement your own management logic. A typical example of this is the creation, retrieval and deletion (commonly referred to as "CRUD operations") of API keys.
+
+The Admin API is a [Lapis](http://leafo.net/lapis/) application, and Kong's level of abstraction makes it easy for you to add endpoints.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you have a relative knowledge of <a href="http://leafo.net/lapis/">Lapis</a>.
+</div>
+
+---
+
+### Adding endpoints to the Admin API
+
+Kong will detect and load your endpoints if they are defined in a module named:
+
+```
+"kong.plugins.<plugin_name>.api"
+```
+
+This module is bound to return a table containing strings describing your routes (See [Lapis routes & URL Patterns](http://leafo.net/lapis/reference/actions.html#routes--url-patterns)) and HTTP verbs they support. Routes are then assigned a simple handler function.
+
+This table is then fed to Lapis (See Lapis' [handling HTTP verbs documentation](http://leafo.net/lapis/reference/actions.html#handling-http-verbs)). Example:
+
+```lua
+return {
+  ["/my-plugin/new/get/endpoint"] = {
+    GET = function(self, dao_factory, helpers)
+      -- ...
+    end
+  }
+}
+```
+
+The handler function takes three arguments, which are, in order:
+
+- `self`: The request object. See [Lapis request object](http://leafo.net/lapis/reference/actions.html#request-object)
+- `dao_factory`: The DAO Factory. See the [datastore]({{page.book.chapters.access-the-datastore}}) chapter of this guide.
+- `helpers`: A table containing a few helpers, described below.
+
+In addition to the HTTPS verbs it supports, a route table can also contain two other keys:
+
+- **before**: as in [Lapis](http://leafo.net/lapis/reference/actions.html#handling-http-verbs), a before_filter that runs before the executed verb action.
+- **on_error**: a custom error handler function that overrides the one provided by Kong. See Lapis' [capturing recoverable errors](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) documentation.
+
+---
+
+### Helpers
+
+When handling a request on the Admin API, there are times when you want to send back responses and handle errors, to help you do so the third parameter `helpers` is a table with the following properties:
+
+- `responses`: a module with helper functions to send HTTP responses.
+- `yield_error`: the [yield_error](http://leafo.net/lapis/reference/exception_handling.html#capturing-recoverable-errors) function from Lapis. To call when your handler encounters an error (from a DAO, for example). Since all Kong errors are tables with context, it can send the appropriate response code depending on the error (Internal Server Error, Bad Request, etc...).
+
+#### crud_helpers
+
+Since most of the operations you will perform in your endpoints will be CRUD operations, you can also use the `kong.api.crud_helpers` module. This module provides you with helpers for any insert, retrieve, update or delete operations and performs the necessary DAO operations and replies with the appropriate HTTP status codes. It also provides you with functions to retrieve parameters from the path, such as an API's name or id, or a Consumer's username or id.
+
+Example:
+
+```lua
+local crud = require "kong.api.crud_helpers"
+
+return {
+  ["/consumers/:username_or_id/key-auth/"] = {
+    before = function(self, dao_factory, helpers)
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+      self.params.consumer_id = self.consumer.id
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      crud.paginated_set(self, dao_factory.keyauth_credentials)
+    end,
+
+    PUT = function(self, dao_factory)
+      crud.put(self.params, dao_factory.keyauth_credentials)
+    end,
+
+    POST = function(self, dao_factory)
+      crud.post(self.params, dao_factory.keyauth_credentials)
+    end
+  }
+}
+```
+
+---
+
+Next: [Write tests for your plugin]({{page.book.next}})
+
+[Admin API]: /docs/{{page.kong_version}}/admin-api/

--- a/app/docs/0.14.x/plugin-development/custom-entities.md
+++ b/app/docs/0.14.x/plugin-development/custom-entities.md
@@ -1,0 +1,179 @@
+---
+title: Plugin Development - Custom Entities
+book: plugin_dev
+chapter: 6
+---
+
+# {{page.title}}
+
+#### Modules
+
+```
+"kong.plugins.<plugin_name>.schema.migrations"
+"kong.plugins.<plugin_name>.daos"
+```
+
+---
+
+Your plugin might need to store more than its configuration in the database. In that case, Kong provides you with an abstraction on top of its primary datastores which allows you to store custom entities.
+
+As explained in the [previous chapter]({{page.book.previous}}), Kong interacts with the model layer through classes we refer to as "DAOs", and available on a singleton often refered to as the "DAO Factory". This chapter will explain how to to provide an abstraction for your own entities.
+
+---
+
+### Create a migration file
+
+Once you have defined your model, you must create your migration modules which will be executed by Kong to create the table in which your records of your entity will be stored. A migration file simply holds an array of migrations, and returns them.
+
+Since Kong `0.8.0`, both Cassandra and PostgreSQL are supported, which requires that your plugin implements its migrations for both databases.
+
+Each migration must bear a unique name, and `up` and `down` fields. Such fields can either be strings of SQL/CQL queries for simple migrations, or actual Lua code to execute for complex ones. The `up` field will be executed when Kong migrates **forward**. It must bring your database's schema to the latest state required by your plugin. The `down` field must execute the necessary actions to revert your schema to its previous state, before `up` was ran.
+
+One of the main benefits of this approach is should you need to release a new version of your plugin that modifies a model, you can simply add new migrations to the array before releasing your plugin. Another benefit is that it is also possible to revert such migrations.
+
+As described in the [file structure]({{page.book.chapters.file-structure}}) chapter, your migrations modules must be named:
+
+```
+"kong.plugins.<plugin_name>.migrations.cassandra"
+"kong.plugins.<plugin_name>.migrations.postgres"
+```
+
+Here is an example of how one would define a migration file to store API keys:
+
+```lua
+-- cassandra.lua
+return {
+  {
+    name = "2015-07-31-172400_init_keyauth",
+    up =  [[
+      CREATE TABLE IF NOT EXISTS keyauth_credentials(
+        id uuid,
+        consumer_id uuid,
+        key text,
+        created_at timestamp,
+        PRIMARY KEY (id)
+      );
+
+      CREATE INDEX IF NOT EXISTS ON keyauth_credentials(key);
+      CREATE INDEX IF NOT EXISTS keyauth_consumer_id ON keyauth_credentials(consumer_id);
+    ]],
+    down = [[
+      DROP TABLE keyauth_credentials;
+    ]]
+  }
+}
+```
+
+```lua
+-- postgres.lua
+return {
+  {
+    name = "2015-07-31-172400_init_keyauth",
+    up = [[
+      CREATE TABLE IF NOT EXISTS keyauth_credentials(
+        id uuid,
+        consumer_id uuid REFERENCES consumers (id) ON DELETE CASCADE,
+        key text UNIQUE,
+        created_at timestamp without time zone default (CURRENT_TIMESTAMP(0) at time zone 'utc'),
+        PRIMARY KEY (id)
+      );
+
+      DO $$
+      BEGIN
+        IF (SELECT to_regclass('public.keyauth_key_idx')) IS NULL THEN
+          CREATE INDEX keyauth_key_idx ON keyauth_credentials(key);
+        END IF;
+        IF (SELECT to_regclass('public.keyauth_consumer_idx')) IS NULL THEN
+          CREATE INDEX keyauth_consumer_idx ON keyauth_credentials(consumer_id);
+        END IF;
+      END$$;
+    ]],
+    down = [[
+      DROP TABLE keyauth_credentials;
+    ]]
+  }
+}
+```
+
+- `name`: Must be a unique string. The format does not matter but can help you debug issues while developing your plugin, so make sure to name it in a relevant way.
+- `up`: Executed when Kong migrates **forward**.
+- `down`: Executed when Kong migrates **backward**.
+
+While Postgres does, Cassandra does not support constraints such as "NOT NULL", "UNIQUE" or "FOREIGN KEY", but Kong provides you with such features when you define your model's schema. bear in mind that this schema will be the same for both PostgreSQL and Cassandra, hence, you might trade-off a pure SQL schema for one that works with Cassandra too.
+
+**IMPORTANT**: if your `schema` uses a `unique` constraint, then Kong will enforce it for Cassandra, but for Postgres you must set this constraint in the `migrations` file.
+
+---
+
+### Retrieve your custom DAO from the Dao Factory
+
+To make the DAO Factory load your custom DAO(s), you will simply need to define your entity's schema (just like the schemas describing your [plugin configuration]({{page.book.chapters.plugin-configuration}})). This schema contains a few more values since it must describes which table the entity relates to in the datastore, constraints on its fields such as foreign keys, non-null constraints and such.
+
+This schema is to be defined in a module named:
+
+```
+"kong.plugins.<plugin_name>.daos"
+```
+
+Once that module returns your entity's schema, and assuming your plugin is loaded by Kong (see the `custom_plugins` property in `kong.yml`), the DAO Factory will use it to instanciate a DAO object.
+
+Here is an example of how one would define a schema to store API keys in a his or her database:
+
+```lua
+-- daos.lua
+local SCHEMA = {
+  primary_key = {"id"},
+  table = "keyauth_credentials", -- the actual table in the database
+  fields = {
+    id = {type = "id", dao_insert_value = true}, -- a value to be inserted by the DAO itself (think of serial ID and the uniqueness of such required here)
+    created_at = {type = "timestamp", immutable = true, dao_insert_value = true}, -- also interted by the DAO itself
+    consumer_id = {type = "id", required = true, foreign = "consumers:id"}, -- a foreign key to a Consumer's id
+    key = {type = "string", required = false, unique = true} -- a unique API key
+  }
+}
+
+return {keyauth_credentials = SCHEMA} -- this plugin only results in one custom DAO, named `keyauth_credentials`
+```
+
+Since your plugin might have to deal with multiple custom DAOs (in the case when you want to store several entities), this module is bound to return a key/value table where keys are the name on which the custom DAO will be available in the DAO Factory.
+
+You will have noticed a few new properties in the schema definition (compared to your [schema.lua]({{page.book.chapters.plugin-configuration}}) file):
+
+| Property name         | Lua type                  | Description
+|-----------------------|---------------------------|-------------
+| `primary_key`         | Integer indexed table     | An array of each part of your column family's primary key. It also supports **composite keys**, even if all Kong entities currently use a simple `id` for usability of the [Admin API]. If your primary key is composite, only include what makes your **partition key**.
+| `fields.*.dao_insert_value` | Boolean              | If true, specifies that this field is to be automatically populated by the DAO (in the base_dao implementation) depending on it's type. A property of type `id` will be a generated uuid, and `timestamp` a timestamp with second-precision.
+| `fields.*.queryable`  | Boolean                   | If true, specifies that Cassandra maintains an index on the specified column. This allows for querying the column family filtered by this column.
+| `fields.*.foreign`    | String                    | Specifies that this column is a foreign key to another entity's column. The format is: `dao_name:column_name`. This makes it up for Cassandra not supporting foreign keys. When the parent row will be deleted, Kong will also delete rows containing the parent's column value.
+
+Your DAO will now be loaded by the DAO Factory and available as one of its properties:
+
+```lua
+local singletons = require "kong.singletons"
+local dao_factory = singletons.dao
+
+local keys_dao = dao_factory.keyauth_credentials
+
+local key_credential, err = keys_dao:insert({
+  consumer_id = consumer.id,
+  key = "abcd"
+})
+```
+
+The DAO name (`keyauth_credentials`) with which it is accessible from the DAO Factory depends on the key with which you exported your DAO in the returned table of `daos.lua`.
+
+---
+
+### Caching custom entities
+
+Sometimes custom entities are required on every request/response, which in turn triggers a query on the datastore every time. This is very inefficient because querying the datastore adds latency and slows the request/response down, and the resulting increased load on the datastore could affect the datastore performance itself and, in turn, other Kong nodes.
+
+When a custom entity is required on every request/response it is good practice to cache it in-memory by leveraging the in-memory cache API that Kong provides.
+
+The next chapter will focus on caching custom entities, and invalidating them when they change in the datastore: [Caching custom entities]({{page.book.next}}).
+
+---
+
+Next: [Caching custom entities &rsaquo;]({{page.book.next}})
+
+[Admin API]: /docs/{{page.kong_version}}/admin-api/

--- a/app/docs/0.14.x/plugin-development/custom-logic.md
+++ b/app/docs/0.14.x/plugin-development/custom-logic.md
@@ -1,0 +1,245 @@
+---
+title: Plugin Development - Write custom logic
+book: plugin_dev
+chapter: 3
+---
+
+# {{page.title}}
+
+#### Module
+
+```
+"kong.plugins.<plugin_name>.handler"
+```
+
+---
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you are familiar with
+  <a href="http://www.lua.org/">Lua</a> and the
+  <a href="https://github.com/openresty/lua-nginx-module">lua-nginx-module API</a>.
+</div>
+
+Kong allows you to execute custom code at different times in the lifecycle of a
+request. To do so, you have to implement one or several of the methods of the
+`base_plugin.lua` interface. Those methods are to be implemented in a module
+at: `"kong.plugins.<plugin_name>.handler"`
+
+---
+
+### Available request contexts
+
+Kong allows you to write your code in all of the lua-nginx-module contexts.
+Each function to implement in your `handler.lua` file will be executed when the
+context is reached for a request:
+
+| Function name           | lua-nginx-module context           | Description
+|-------------------------|------------------------------------|--------------
+| `:init_worker()`         | [init_worker_by_lua]               | Executed upon every Nginx worker process's startup.
+| `:certificate()`         | [ssl_certificate_by_lua_block]     | Executed during the SSL certificate serving phase of the SSL handshake.
+| `:rewrite()`             | [rewrite_by_lua_block]             | Executed for every request upon its reception from a client as a rewrite phase handler. *NOTE* in this phase neither the `api` nor the `consumer` have been identified, hence this handler will only be executed if the plugin was configured as a global plugin!
+| `:access()`              | [access_by_lua]                    | Executed for every request from a client and before it is being proxied to the upstream service.
+| `:header_filter()`       | [header_filter_by_lua]             | Executed when all response headers bytes have been received from the upstream service.
+| `:body_filter()`         | [body_filter_by_lua]               | Executed for each chunk of the response body received from the upstream service. Since the response is streamed back to the client, it can exceed the buffer size and be streamed chunk by chunk. hence this method can be called multiple times if the response is large. See the lua-nginx-module documentation for more details.
+| `:log()`                 | [log_by_lua]                       | Executed when the last response byte has been sent to the client.
+
+All of those functions take one parameter given by Kong: the configuration of your plugin. This parameter is a simple Lua table, and will contain values defined by your users, according to the schema of your choice. More on that in the [next chapter]({{page.book.next}}).
+
+[ssl_certificate_by_lua_block]: https://github.com/openresty/lua-nginx-module#ssl_certificate_by_lua_block
+[init_worker_by_lua]: https://github.com/openresty/lua-nginx-module#init_worker_by_lua
+[rewrite_by_lua_block]: https://github.com/openresty/lua-nginx-module#rewrite_by_lua_block
+[access_by_lua]: https://github.com/openresty/lua-nginx-module#access_by_lua
+[header_filter_by_lua]: https://github.com/openresty/lua-nginx-module#header_filter_by_lua
+[body_filter_by_lua]: https://github.com/openresty/lua-nginx-module#body_filter_by_lua
+[log_by_lua]: https://github.com/openresty/lua-nginx-module#log_by_lua
+
+---
+
+### handler.lua specifications
+
+The `handler.lua` file must return a table implementing the functions you wish
+to be executed. In favor of brevity, here is a commented example module
+implementing all the available methods:
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> Kong uses the
+  <a href="https://github.com/rxi/classic">rxi/classic</a> module to simulate
+  classes in Lua and ease the inheritence pattern.
+</div>
+
+```lua
+-- Extending the Base Plugin handler is optional, as there is no real
+-- concept of interface in Lua, but the Base Plugin handler's methods
+-- can be called from your child implementation and will print logs
+-- in your `error.log` file (where all logs are printed).
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+-- Your plugin handler's constructor. If you are extending the
+-- Base Plugin handler, it's only role is to instanciate itself
+-- with a name. The name is your plugin name as it will be printed in the logs.
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:init_worker()
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.init_worker(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:certificate(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.certificate(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:rewrite(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.rewrite(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:access(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.access(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:header_filter(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.header_filter(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:body_filter(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.body_filter(self)
+
+  -- Implement any custom logic here
+end
+
+function CustomHandler:log(config)
+  -- Eventually, execute the parent implementation
+  -- (will log that your plugin is entering this context)
+  CustomHandler.super.log(self)
+
+  -- Implement any custom logic here
+end
+
+-- This module needs to return the created table, so that Kong
+-- can execute those functions.
+return CustomHandler
+```
+
+Of course, the logic of your plugin itself can be abstracted away in another
+module, and called from your `handler` module. Many existing plugins have
+already chosen this pattern when their logic is verbose, but it is purely
+optional:
+
+```lua
+local BasePlugin = require "kong.plugins.base_plugin"
+
+-- The actual logic is implemented in those modules
+local access = require "kong.plugins.my-custom-plugin.access"
+local body_filter = require "kong.plugins.my-custom-plugin.body_filter"
+
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  -- Execute any function from the module loaded in `access`,
+  -- for example, `execute()` and passing it the plugin's configuration.
+  access.execute(config)
+end
+
+function CustomHandler:body_filter(config)
+  CustomHandler.super.body_filter(self)
+
+  -- Execute any function from the module loaded in `body_filter`,
+  -- for example, `execute()` and passing it the plugin's configuration.
+  body_filter.execute(config)
+end
+
+return CustomHandler
+```
+
+---
+
+### Plugins execution order
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This is still a work-in-progress API. For thoughts on
+  how plugins execution order should be configurable in the future, see
+  <a href="https://github.com/Mashape/kong/issues/267">Mashape/kong#267</a>.
+</div>
+
+Some plugins might depend on the execution of others to perform some
+operations. For example, plugins relying on the identity of the consumer have
+to run **after** authentication plugins. Considering this, Kong defines
+**priorities** between plugins execution to ensure that order is respected.
+
+Your plugin's priority can be configured via a property accepting a number in
+the returned handler table:
+
+```lua
+CustomHandler.PRIORITY = 10
+```
+
+The higher the priority, the sooner your plugin's phases will be executed in
+regard to other plugins' phases (such as `:access()`, `:log()`, etc...).
+
+The current order of execution for the bundled plugins is:
+
+Plugin                    | Priority
+-------------------------:|:------------
+bot-detection             | 2500
+cors                      | 2000
+jwt                       | 1005
+oauth2                    | 1004
+key-auth                  | 1003
+ldap-auth                 | 1002
+basic-auth                | 1001
+hmac-auth                 | 1000
+ip-restriction            | 990
+request-size-limiting     | 951
+acl                       | 950
+rate-limiting             | 901
+response-ratelimiting     | 900
+request-transformer       | 801
+response-transformer      | 800
+aws-lambda                | 750
+http-log                  | 12
+statsd                    | 11
+datadog                   | 10
+file-log                  | 9
+udp-log                   | 8
+tcp-log                   | 7
+loggly                    | 6
+runscope                  | 5
+syslog                    | 4
+galileo                   | 3
+request-termination       | 2
+correlation-id            | 1
+
+---
+
+Next: [Store configuration &rsaquo;]({{page.book.next}})
+
+[lua-nginx-module]: https://github.com/openresty/lua-nginx-module

--- a/app/docs/0.14.x/plugin-development/distribution.md
+++ b/app/docs/0.14.x/plugin-development/distribution.md
@@ -1,0 +1,297 @@
+---
+title: Plugin Development - (un)Install your plugin
+book: plugin_dev
+chapter: 10
+---
+
+# {{page.title}}
+
+Custom plugins for Kong consist of Lua source files that need to be in the file
+system of each of your Kong nodes. This guide will provide you with
+step-by-step instructions that will make a Kong node aware of your custom
+plugin(s).
+
+These steps should be applied to each node in your Kong cluster, to ensure the
+custom plugin(s) are available on each one of them.
+
+
+### Table of Contents
+
+- [Packaging sources](#packaging-sources)
+- [Installing the plugin](#installing-the-plugin)
+- [Load the plugin](#load-the-plugin)
+- [Verify loading the plugin](#verify-loading-the-plugin)
+- [Removing a plugin](#removing-a-plugin)
+- [Distribute your plugin](#distribute-your-plugin)
+- [Troubleshooting](#troubleshooting)
+
+### Packaging sources
+
+You can either use a regular packing strategy (eg. `tar`), or use the LuaRocks
+package manager to do it for you. We recommend LuaRocks as it is installed
+along with Kong when using one of the official distribution packages.
+
+When using LuaRocks, you must create a `rockspec` file, which specifies the
+package contents. For an example see the [Kong plugin
+template][plugin-template], for more info about the format see the LuaRocks
+[documentation on rockspecs][rockspec].
+
+Pack your rock using the following command (from the plugin repo):
+
+    # install it locally (based on the `.rockspec` in the current directory)
+    $ luarocks make
+
+    # pack the installed rock
+    $ luarocks pack <plugin-name> <version>
+
+Assuming your plugin rockspec is called
+`kong-plugin-myPlugin-0.1.0-1.rockspec`, the above would become;
+
+    $ luarocks pack kong-plugin-myPlugin 0.1.0-1
+
+The LuaRocks `pack` command has now created a `.rock` file (this is simply a
+zip file containing everything needed to install the rock).
+
+If you do not or cannot use LuaRocks, then use `tar` to pack the
+`.lua` files of which your plugin consists into a `.tar.gz` archive. You can
+also include the `.rockspec` file if you do have LuaRocks on the target
+systems.
+
+The contents of this archive should be close to the following:
+
+    $ tree <plugin-name>
+    <plugin-name>
+    ├── INSTALL.txt
+    ├── README.md
+    ├── kong
+    │   └── plugins
+    │       └── <plugin-name>
+    │           ├── handler.lua
+    │           └── schema.lua
+    └── <plugin-name>-<version>.rockspec
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Installing the plugin
+
+For a Kong node to be able to use the custom plugin, the custom plugin's Lua
+sources must be installed on your host's file system. There are multiple ways
+of doing so: via LuaRocks, or manually. Choose one, and jump to section 3.
+
+1. Via LuaRocks from the created 'rock'
+
+    The `.rock` file is a self contained package that can be installed locally
+    or from a remote server.
+
+    If the `luarocks` utility is installed in your system (this is likely the
+    case if you used one of the official installation packages), you can
+    install the 'rock' in your LuaRocks tree (a directory in which LuaRocks
+    installs Lua modules).
+
+    It can be installed by doing:
+
+        $ luarocks install <rock-filename>
+
+    The filename can be a local name, or any of the supported methods, eg.
+    `http://myrepository.lan/rocks/myplugin-0.1.0-1.all.rock`
+
+2. Via LuaRocks from the source archive
+
+    If the `luarocks` utility is installed in your system (this is likely the
+    case if you used one of the official installation packages), you can
+    install the Lua sources in your LuaRocks tree (a directory in which
+    LuaRocks installs Lua modules).
+
+    You can do so by changing the current directory to the extracted archive,
+    where the rockspec file is:
+
+        $ cd <plugin-name>
+
+    And then run the following:
+
+        $ luarocks make
+
+    This will install the Lua sources in `kong/plugins/<plugin-name>` in your
+    system's LuaRocks tree, where all the Kong sources are already present.
+
+3. Manually
+
+    A more conservative way of installing your plugin's sources is
+    to avoid "polluting" the LuaRocks tree, and instead, point Kong
+    to the directory containing them.
+
+    This is done by tweaking the `lua_package_path` property of your Kong
+    configuration. Under the hood, this property is an alias to the `LUA_PATH`
+    variable of the Lua VM, if you are familiar with it.
+
+    Those properties contain a semicolon-separated list of directories in
+    which to search for Lua sources. It should be set like so in your Kong
+    configuration file:
+
+        lua_package_path = /<path-to-plugin-location>/?.lua;;
+
+    Where:
+
+    * `/<path-to-plugin-location>` is the path to the directory containing the
+      extracted archive. It should be the location of the `kong` directory
+      from the archive.
+    * `?` is a placeholder that will be replaced by
+      `kong.plugins.<plugin-name>` when Kong will try to load your plugin. Do
+      not change it.
+    * `;;` a placeholder for the "the default Lua path". Do not change it.
+
+    Example:
+
+    The plugin `something` being located on the file system such that the
+    handler file is:
+
+        /usr/local/custom/kong/plugins/<something>/handler.lua
+
+    The location of the `kong` directory is: `/usr/local/custom`, hence the
+    proper path setup would be:
+
+        lua_package_path = /usr/local/custom/?.lua;;
+
+    Multiple plugins:
+
+    If you wish to install two or more custom plugins this way, you can set
+    the variable to something like:
+
+        lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+
+    * `;` is the separator between directories.
+    * `;;` still means "the default Lua path".
+
+    Note: you can also set this property via its environment variable
+    equivalent: `KONG_LUA_PACKAGE_PATH`.
+
+Reminder: regardless of which method you are using to install your plugin's
+sources, you must still do so for each node in your Kong cluster.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Load the plugin
+
+You must now add the custom plugin's name to the `custom_plugins` list in your
+Kong configuration (on each Kong node):
+
+    custom_plugins = <plugin-name>
+
+If you are using two or more custom plugins, insert commas in between, like so:
+
+    custom_plugins = plugin1,plugin2
+
+Note: you can also set this property via its environment variable equivalent:
+`KONG_CUSTOM_PLUGINS`.
+
+Reminder: don't forget to update the `custom_plugins` directive for each node
+in your Kong cluster.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Verify loading the plugin
+
+You should now be able to start Kong without any issue. Consult your custom
+plugin's instructions on how to enable/configure your plugin
+on an API or Consumer object.
+
+To make sure your plugin is being loaded by Kong, you can start Kong with a
+`debug` log level:
+
+    log_level = debug
+
+or:
+
+    KONG_LOG_LEVEL=debug
+
+Then, you should see the following log for each plugin being loaded:
+
+    [debug] Loading plugin <plugin-name>
+
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Removing a plugin
+
+There are three steps to completely remove a plugin.
+
+1. Remove the plugin from your Kong api configuration. Make sure that it
+   is no longer applied globally nor for any API or consumer. This has to be
+   done only once for the entire Kong cluster, no restart/reload required.
+   This step in itself will make that the plugin is no longer in use. But it
+   remains available and it is still possible to re-apply the plugin.
+
+2. Remove the plugin from the `custom_plugins` directive (on each Kong node).
+   Make sure to have completed step 1 before doing so. After this step
+   it will be impossible for anyone to re-apply the plugin to any Kong
+   api, consumer, or even globally. This step requires to restart/reload the
+   Kong node to take effect.
+
+3. To remove the plugin thoroughly, delete the plugin-related files from
+   each of the Kong nodes. Make sure to have completed step 2, including
+   restarting/reloading Kong, before deleting the files. If you used LuaRocks
+   to install the plugin, you can do `luarocks remove <plugin-name>` to remove
+   it.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Distribute your plugin
+
+The preferred way to do so is to use [Luarocks](https://luarocks.org/), a
+package manager for Lua modules. It calls such modules "rocks". **Your module
+does not have to live inside the Kong repository**, but it can be if that's
+how you'd like to maintain your Kong setup.
+
+By defining your modules (and their eventual dependencies) in a [rockspec]
+file, you can install those modules on your platform via Luarocks. You can
+also upload your module on Luarocks and make it available to everyone!
+
+Here is an example rockspec which would use the "builtin" build type to define
+modules in Lua notation and their corresponding file:
+
+
+For an example see the [Kong plugin template][plugin-template], for more info
+about the format see the LuaRocks [documentation on rockspecs][rockspec].
+
+[Back to TOC](#table-of-contents)
+
+---
+
+### Troubleshooting
+
+Kong can fail to start because of a misconfigured custom plugin for several
+reasons:
+
+* "plugin is in use but not enabled" -> You configured a custom plugin from
+  another node, and that the plugin configuration is in the database, but the
+  current node you are trying to start does not have it in its `custom_plugins`
+  directive. To resolve, add the plugin's name to the node's `custom_plugins`
+  directive.
+
+* "plugin is enabled but not installed" -> The plugin's name is present in the
+  `custom_plugins` directive, but that Kong is unable to load the `handler.lua`
+  source file from the file system. To resolve, make sure that the
+  lua_package_path directive is properly set to load this plugin's Lua sources.
+
+* "no configuration schema found for plugin" -> The plugin is installed,
+  enabled in custom_plugins, but Kong is unable to load the `schema.lua`
+  source file from the file system.
+  To resolve, make sure that the `schema.lua` file is present alongside the
+  plugin's `handler.lua` file.
+
+[Back to TOC](#table-of-contents)
+
+---
+
+[rockspec]: https://github.com/keplerproject/luarocks/wiki/Creating-a-rock
+[plugin-template]: https://github.com/Kong/kong-plugin

--- a/app/docs/0.14.x/plugin-development/entities-cache.md
+++ b/app/docs/0.14.x/plugin-development/entities-cache.md
@@ -1,0 +1,292 @@
+---
+title: Plugin Development - Caching custom entities
+book: plugin_dev
+chapter: 7
+---
+
+# {{page.title}}
+
+#### Modules
+
+```
+"kong.plugins.<plugin_name>.daos"
+"kong.plugins.<plugin_name>.hooks"
+```
+
+---
+
+Your plugin may need to frequently access custom entities (explained in the
+[previous chapter]({{page.book.previous}})) on every request and/or response.
+Usually, loading them once and caching them in-memory dramatically improves
+the performance while making sure the datastore is not stressed with an
+increased load.
+
+Think of an api-key authentication plugin that needs to validate the api-key on
+every request, thus loading the custom credential object from the datastore on
+every request. When the client provides an api-key along with the request,
+normally you would query the datastore to check if that key exists, and then
+either block the request or retrieve the Consumer ID to identify the user. This
+would happen on every request, and it would be very inefficient:
+
+* Querying the datastore adds latency on every request, making the request
+  processing slower.
+* The datastore would also be affected by an increase of load, potentially
+  crashing or slowing down, which in turn would affect every Kong
+  node.
+
+To avoid querying the datastore every time, we can cache custom entities
+in-memory on the node, so that frequent entity lookups don't trigger a
+datastore query every time (only the first time), but happen in-memory, which
+is much faster and reliable that querying it from the datastore (especially
+under heavy load).
+
+---
+
+### Caching custom entities
+
+Once you have defined your custom entities, you can cache them in-memory in
+your code by using the `singletons.cache` module provided by Kong:
+
+```
+local singletons = require "kong.singletons"
+local cache = singletons.cache
+```
+
+There are 2 levels of cache:
+
+1. L1: Lua memory cache - local to an nginx worker
+   This can hold any type of Lua value.
+2. L2: Shared memory cache (SHM) - local to an nginx node, but shared between
+   all workers. This can only hold scalar values, and hence requires
+   (de)serialization.
+
+When data is fetched from the database, it will be stored in both caches. Now
+if the same worker process requests the data again, it will retrieve the
+previously-deserialized data from the Lua memory cache. If a different
+worker within the same nginx node requests that data, it will find the data
+in the SHM, deserialize it (and store it in its own Lua memory cache) and
+then return it.
+
+This module exposes the following functions:
+
+Function name                                 | Description
+----------------------------------------------|---------------------------
+`value, err = cache:get(key, opts?, cb, ...)` | Retrieves the value from the cache. If the cache does not have value (miss), invokes `cb` in protected mode. `cb` must return one (and only one) value that will be cached. It *can* throw errors, as those will be caught and properly logged by Kong, at the `ngx.ERR` level. This function **does** cache negative results (`nil`). As such, one must rely on its second argument `err` when checking for errors.
+`ttl, err, value = cache:probe(key)`          | Checks if a value is cached. If it is, returns its remaining TTL. It not, returns `nil`. The value being cached can also be a negative caching. The third return value is the value being cached itself.
+`cache:invalidate_local(key)`                       | Evicts a value from the node's cache.
+`cache:invalidate(key)`                             | Evicts a value from the node's cache **and** propagates the eviction events to all other nodes in the cluster.
+`cache:purge()`                                     | Evicts **all** values from the node's cache.
+
+Bringing back our authentication plugin example, to lookup a credential with a
+specific api-key, we would write something like:
+
+```lua
+-- access.lua
+local singletons = require "kong.singletons"
+
+local function load_entity_key(api_key)
+  -- IMPORTANT: the callback is executed inside a lock, hence we cannot terminate
+  -- a request here, we MUST always return.
+  local apikeys, err = dao.apikeys:find_all({key = api_key}) -- Lookup in the datastore
+  if err then
+    error(err) -- caught by kong.cache and logged
+  end
+
+  if not apikeys then
+    return nil -- nothing was found (cached for `neg_ttl`)
+  end
+
+  -- assuming the key was unique, we always only have 1 value...
+  return apikeys[1] -- cache the credential (cached for `ttl`)
+end
+
+-- retrieve the apikey from the request querystring
+local apikey = request.get_uri_args().apikey
+
+-- We are using cache.get to first check if the apikey has been already
+-- stored into the in-memory cache at the key: "apikeys." .. apikey
+-- If it's not, then we lookup the datastore and return the credential
+-- object. Internally cache.get will save the value in-memory, and then
+-- return the credential.
+local credential, err = cache:get("apikeys." .. apikey, nil,
+                                  load_entity_key, apikey)
+if err then
+  return response.HTTP_INTERNAL_SERVER_ERROR(err)
+end
+
+if not credential then
+  -- no credentials in cache nor datastore
+  return responses.send_HTTP_FORBIDDEN("Invalid authentication credentials")
+end
+
+-- set an upstream header if the credential exists and is valid
+ngx.req.set_header("X-API-Key", credential.apikey)
+```
+
+With the above mechanism in place, once a Consumer has made a request with
+their API key, the cache will be considered warm and subsequent requests
+won't result in a database query.
+
+#### Updating or deleting a custom entity
+
+Every time a cached custom entity is updated or deleted in the datastore (i.e.
+using the Admin API), it creates an inconsistency between the data in
+the datastore, and the data cached in the Kong nodes' memory. To avoid this
+inconsistency, we need to evict the cached entity from the in-memory store and
+force Kong to request it again from the datastore. We refer to this process as
+cache invalidation.
+
+---
+
+### Cache invalidation for your entities
+
+If you wish that your cached entities be invalidated upon a CRUD operation
+rather than having to wait for them to reach their TTL, you have to follow
+a few steps. This process can be automated since 0.11.0 for most entities,
+but manually subscribing to some CRUD events might be required to invalidate
+some entities with more complex relationships.
+
+#### Automatic cache invalidation
+
+Cache invalidation can be provided out of the box for your entities if you
+rely on the `cache_key` property of your entity's schema. For example, in the
+following schema:
+
+```lua
+local SCHEMA = {
+  primary_key = { "id" },
+  table = "keyauth_credentials",
+  cache_key = { "key" }, -- cache key for this entity
+  fields = {
+    id = { type = "id" },
+    created_at = { type = "timestamp", immutable = true },
+    consumer_id = { type = "id", required = true, foreign = "consumers:id"},
+    key = { type = "string", required = false, unique = true }
+  }
+}
+
+return { keyauth_credentials = SCHEMA }
+```
+
+We can see that we declare the cache key of this API key entity to be its
+`key` attribute. We use `key` here because it has a unique constraints
+applied to it. Hence, the attributes added to `cache_key` should result in
+a unique combination, so that no two entities could yield the same cache key.
+
+Adding this value allows you to use the following function on the DAO of that
+entity:
+
+```lua
+cache_key = dao:cache_key(arg1, arg2, arg3, ...)
+```
+
+Where the arguments must be the attributes specified in your schema's
+`cache_key` property, in the order they were specified. This function then
+computes a string value `cache_key` that is ensured to be unique.
+
+For example, if we were to generate the cache_key of an API key:
+
+```lua
+local cache_key = singletons.dao.keyauth_credentials:cache_key("abcd")
+```
+
+This would produce a cache_key for the API key `"abcd"` (retrieved from one
+of the query's arguments) that we can the use to retrieve the key from the
+cache (or fetch from the database if the cache is a miss):
+
+```lua
+local apikey = request.get_uri_args().apikey
+local cache_key = singletons.dao.keyauth_credentials:cache_key(apikey)
+
+local credential, err = cache:get(cache_key, nil, load_entity_key, apikey)
+if err then
+  return response.HTTP_INTERNAL_SERVER_ERROR(err)
+end
+
+-- do something with the credential
+```
+
+If the `cache_key` is generated like so and specified in an entity's schema,
+cache invalidation will be an automatic process: every CRUD operation that
+affects this API key will be make Kong generate the affected `cache_key`, and
+broadcast it to all of the other nodes on the cluster so they can evict
+that particular value from their cache, and fetch the fresh value from the
+datastore on the next request.
+
+When a parent entity is receiving a CRUD operation (e.g. the Consumer owning
+this API key, as per our schema's `consumer_id` attribute), Kong performs the
+cache invalidation mechanism for both the parent and the child entity.
+
+**Note**: Be aware of the negative caching that Kong provides. In the above
+example, if there is no API key in the datastore for a given key, the cache
+module will store the miss just as if it was a hit. This means that a
+"Create" event (one that would create an API key with this given key) is also
+propagated by Kong so that all nodes that stored the miss can evict it, and
+properly fetch the newly created API key from the datastore.
+
+See the [Clustering Guide](/docs/{{page.kong_version}}/clustering/) to ensure
+that you have properly configured your cluster for such invalidation events.
+
+#### Manual cache invalidation
+
+In some cases, the `cache_key` property of an entity's schema is not flexible
+enough, and one must manually invalidate its cache. Reasons for this could be
+that the plugin is not defining a relationship with another entity via the
+traditional `foreign = "parent_entity:parent_attribute"` syntax, or because
+it is not using the `cache_key` method from its DAO, or even because it is
+somehow abusing the caching mechanism.
+
+In those cases, you can manually setup your own subscriber to the same
+invalidation channels Kong is listening to, and perform your own, custom
+invalidation work. This process is similar to the old `hooks.lua` module that
+was required in < 0.11.0 for cache invalidations.
+
+To listen on invalidation channels inside of Kong, implement the following in
+your plugin's `init_worker` handler:
+
+```lua
+function MyCustomHandler:init_worker()
+  local worker_events = singletons.worker_events
+
+  -- listen to all CRUD operations made on Consumers
+  worker_events.register(function(data)
+
+  end, "crud", "consumers")
+
+  -- or, listen to a specific CRUD operation only
+  worker_events.register(function(data)
+    print(data.operation)  -- "update"
+    print(data.old_entity) -- old entity table (only for "update")
+    print(data.entity)     -- new entity table
+    print(data.schema)     -- entity's schema
+  end, "crud", "consumers:update")
+end
+```
+
+Once the above listeners are in place for the desired entities, you can perform
+manual invalidations of any entity that your plugin has cached as you wish so.
+For instance:
+
+```lua
+singletons.worker_events.register(function(data)
+  if data.operation == "delete" then
+    local cache_key = data.entity.id
+    singletons.cache:invalidate("prefix:" .. cache_key)
+  end
+end, "crud", "consumers")
+```
+
+### Extending the Admin API
+
+As you are probably aware, the [Admin API] is where Kong users communicate with
+Kong to setup their APIs and plugins. It is likely that they also need to be
+able to interact with the custom entities you implemented for your plugin (for
+example, creating and deleting API keys). The way you would do this is by
+extending the Admin API, which we will detail in the next chapter: [Extending
+the Admin API]({{page.book.next}}).
+
+---
+
+Next: [Extending the Admin API &rsaquo;]({{page.book.next}})
+
+[Admin API]: /docs/{{page.kong_version}}/admin-api/

--- a/app/docs/0.14.x/plugin-development/file-structure.md
+++ b/app/docs/0.14.x/plugin-development/file-structure.md
@@ -1,0 +1,108 @@
+---
+title: Plugin Development - File Structure
+book: plugin_dev
+chapter: 2
+---
+
+# {{page.title}}
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This chapter assumes that you are familiar with
+  <a href="http://www.lua.org/">Lua</a>.
+</div>
+
+Consider your plugin as a set of [Lua
+modules](http://www.lua.org/manual/5.1/manual.html#6.3). Each file described in
+this chapter is to be considered as a separate module. Kong will detect and
+load your plugin's modules if their names follow this convention:
+
+```
+"kong.plugins.<plugin_name>.<module_name>"
+```
+
+> Your modules of course need to be accessible through your
+> [package.path](http://www.lua.org/manual/5.1/manual.html#pdf-package.path)
+> variable, which can be tweaked to your needs by the
+> [lua-package-path](https://github.com/openresty/lua-nginx-module#lua_package_path)
+> directive in your Nginx configuration. However, the prefered way of
+> installing plugins is through [Luarocks](https://luarocks.org/). More on that
+> later in this guide.
+
+To make Kong aware that it has to look for your plugin's modules, you'll have
+to add it to the `custom_plugins` property in your configuration file, which
+is a comma-separated list. For example:
+
+```yaml
+custom_plugins = my-custom-plugin # your plugin name here
+```
+
+Now, Kong will try to load the modules described in this chapter. Some of them
+are mandatory, but the ones that are not will be ignored and Kong will consider
+you do not make use of it. For example, Kong will load
+`"kong.plugins.my-custom-plugin.handler"` to retrieve and execute your plugin's
+logic.
+
+Now let's describe what are the modules you can implement and what their
+purpose is.
+
+---
+
+### Basic plugin modules
+
+In its purest form, a plugin consists of two mandatory modules:
+
+```
+simple-plugin
+├── handler.lua
+└── schema.lua
+```
+
+- [handler.lua]: the core of your plugin. It is an interface to implement, in
+  which each function will be run at the desired moment in the lifecycle of a
+  request.
+- [schema.lua]: your plugin probably has to retain some configuration entered
+  by the user. This module holds the *schema* of that configuration and defines
+  rules on it, so that the user can only enter valid configuration values.
+
+---
+
+### Advanced plugin modules
+
+Some plugins might have to integrate deeper with Kong: have their own table in
+the database, expose endpoints in the Admin API, etc... Each of those can be
+done by adding a new module to your plugin. Here is what the structure of a
+plugin would look like if it was implementing all of the optional modules:
+
+```
+complete-plugin
+├── api.lua
+├── daos.lua
+├── handler.lua
+├── migrations
+│   ├── cassandra.lua
+│   └── postgres.lua
+└── schema.lua
+```
+
+Here is the complete list of possible modules to implement and a brief
+description of what their purpose is. This guide will go in details to let you
+master each one of them.
+
+| Module name        | Required   | Description
+|:-------------------|------------|----------
+| [api.lua]          | No         | Defines a list of endpoints to be available in the Admin API to interact with entities custom entities handled by your plugin.
+| [daos.lua]         | No         | Defines a list of DAOs (Database Access Objects) that are abstractions of custom entities needed by your plugin and stored in the datastore.
+| [handler.lua]      | Yes        | An interface to implement. Each function is to be run by Kong at the desired moment in the lifecycle of a request.
+| [migrations/*.lua] | No         | The corresponding migrations for a given datastore. Migrations are only necessary when your plugin has to store custom entities in the database and interact with them through one of the DAOs defined by [daos.lua].
+| [schema.lua]       | Yes        | Holds the schema of your plugin's configuration, so that the user can only enter valid configuration values.
+
+---
+
+Next: [Write custom logic &rsaquo;]({{page.book.next}})
+
+[api.lua]: {{page.book.chapters.admin-api}}
+[daos.lua]: {{page.book.chapters.custom-entities}}
+[hooks.lua]: {{page.book.chapters.plugin-configuration}}
+[handler.lua]: {{page.book.chapters.custom-logic}}
+[schema.lua]: {{page.book.chapters.plugin-configuration}}
+[migrations/*.lua]: {{page.book.chapters.custom-entities}}

--- a/app/docs/0.14.x/plugin-development/index.md
+++ b/app/docs/0.14.x/plugin-development/index.md
@@ -1,0 +1,30 @@
+---
+title: Plugin Development - Introduction
+book: plugin_dev
+chapter: 1
+---
+
+# Plugin development - Introduction
+
+### What are plugins and how do they integrate with Kong?
+
+Before going further, it is necessary to briefly explain how Kong is built, especially how it integrates with Nginx and what Lua has to do with it.
+
+[lua-nginx-module] enables Lua scripting capabilities in Nginx. Instead of compiling Nginx with this module, Kong is distributed along with [OpenResty](https://openresty.org/), which already includes lua-nginx-module. OpenResty is *not* a fork of Nginx, but a bundle of modules extending its capabilities.
+
+Hence, Kong is a Lua application designed to load and execute Lua modules (which we more commonly refer to as "*plugins*") and provides an entire development environment for them, including database abstraction, migrations, helpers and more...
+
+Your plugin will consist of Lua modules which will be loaded and executed by Kong, and it will benefit from two APIs:
+
+- [lua-nginx-module API][lua-nginx-module]: allows interaction with Nginx itself, such as, for example, retrieving the request/response, or accessing Nginx's shared memory zone.
+- **Kong's plugin environment**: allows interaction with the datastore holding your configurations (APIs, Consumers, Plugins...) and various helpers allowing the interaction of plugins between each other. This is the environment that will be described by this guide.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This guide assumes that you are familiar with <a href="http://www.lua.org/">Lua</a> and the <a href="https://github.com/openresty/lua-nginx-module">lua-nginx-module API</a> and will only describe Kong's plugin environment.
+</div>
+
+---
+
+Next: [File structure of a plugin &rsaquo;]({{page.book.next}})
+
+[lua-nginx-module]: https://github.com/openresty/lua-nginx-module

--- a/app/docs/0.14.x/plugin-development/plugin-configuration.md
+++ b/app/docs/0.14.x/plugin-development/plugin-configuration.md
@@ -1,0 +1,214 @@
+---
+title: Plugin Development - Store Configuration
+book: plugin_dev
+chapter: 4
+---
+
+# {{page.title}}
+
+#### Module
+
+```
+"kong.plugins.<plugin_name>.schema"
+```
+
+---
+
+Most of the time, it makes sense for your plugin to be configurable to answer all of your user's needs. Your plugin's configuration is stored in the datastore for Kong to retrieve it and pass it to your [handler.lua]({{page.book.chapters.custom-logic}}) methods when the plugin is being executed.
+
+The configuration consists of a Lua table in Kong that we call a **schema**. It contains key/value properties that the user will set when enabling the plugin through the [Admin API]. Kong provides you with a way of validating the user's configuration for your plugin.
+
+Your plugin's configuration is being verified against your schema when a user issues a request to the [Admin API] to enable or update a plugin on a given Service, Route and/or Consumer.
+
+For example, a user performs the following request:
+
+```bash
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins/ \
+    -d "name=my-custom-plugin" \
+    -d "config.foo=bar"
+```
+
+If all properties of the `config` object are valid according to your schema, then the API would return `201 Created` and the plugin would be stored in the database along with its configuration (`{foo = "bar"}` in this case). If the configuration is not valid, the Admin API would return `400 Bad Request` and the appropriate error messages.
+
+---
+
+### schema.lua specifications
+
+This module is to return a Lua table with properties that will define how your plugins can later be configured by users. Available properties are:
+
+| Property name                 | Lua type    | Default          | Description
+|-------------------------------|-------------|------------------|-------------
+| `no_consumer`                 | Boolean     | `false`          | If true, it will not be possible to apply this plugin to a specific Consumer. This plugin must be applied to Services and Routes only. For example: authentication plugins.
+| `fields`                      | Table       | `{}`             | Your plugin's **schema**. A key/value table of available properties and their rules.
+| `self_check`                  | Function    | `nil`            | A function to implement if you want to perform any custom validation before accepting the plugin's configuration.
+
+The `self_check` function must be implemented as follows:
+
+```lua
+-- @param `schema` A table describing the schema (rules) of your plugin configuration.
+-- @param `config` A key/value table of the current plugin's configuration.
+-- @param `dao` An instance of the DAO (see DAO chapter).
+-- @param `is_updating` A boolean indicating wether or not this check is performed in the context of an update.
+-- @return `valid` A boolean indicating if the plugin's configuration is valid or not.
+-- @return `error` A DAO error (see DAO chapter)
+```
+
+Here is an example of a potential `schema.lua` file:
+
+```lua
+return {
+  no_consumer = true, -- this plugin will only be applied to Services or Routes,
+  fields = {
+    -- Describe your plugin's configuration's schema here.
+  },
+  self_check = function(schema, plugin_t, dao, is_updating)
+    -- perform any custom verification
+    return true
+  end
+}
+```
+
+### Describing your configuration schema
+
+The `fields` property of your `schema.lua` file described the schema of your plugin's configuration. It is a flexible key/value table where each key will be a valid configuration property for your plugin, and each value a table describing the rules for that property. For example:
+
+```lua
+  fields = {
+    some_string = {type = "string", required = true},
+    some_boolean = {type = "boolean", default = false},
+    some_array = {type = "array", enum = {"GET", "POST", "PUT", "DELETE"}}
+  }
+```
+
+Here is the list of accepted rules for a property:
+
+| Rule          | Lua type(s)              | Accepted values                                 | Description
+|---------------|--------------------------|-------------------------------------------------|----------------------------
+| `type`        | string                   | "id", "number", "boolean", "string", "table", "array", "url", "timestamp" | Validates the type of a property.
+| `required`    | boolean                  |                                                 | **Default**: false. If true, the property must be present in the configuration.
+| `unique`      | boolean                  |                                                 | **Default**: false. If true, the value must be unique (see remark below).
+| `default`     | any                      |                                                 | If the property is not specified in the configuration, will set the property to the given value.
+| `immutable`   | boolean                  |                                                 | **Default**: false. If true, the property will not be allowed to be updated once the plugin configuration has been created.
+| `enum`        | table                    | Integer indexed table                           | A list of accepted values for a property. Any value not included in this list will not be accepted.
+| `regex`       | string                   | A valid PCRE regular expression                 | A regex against which to validate the property's value.
+| `schema`      | table                    | A nested schema definition                      | If the property's `type` is table, defines a schema against which to validate those sub-properties.
+| `func`        | function                 |                                                 | A function to perform any custom validation on a property. See later examples for its parameters and return values.
+
+> - **type**: will cast the value retrieved from the request parameters. If the type is not one of the native Lua types, custom verification is performed against it:
+>   - id: must be a string
+>   - timestamp: must be a number
+>   - url: must be a valid URL
+>   - array: must be an integer-indexed table (equivalent of arrays in Lua). In the Admin API, such an array can either be sent by having several times the property's key with different values in the request's body, or comma-delimited through a single body parameter.
+> - **unique**: This property does not make sense for a plugin configuration, but is used when a plugin needs to store custom entities in the datastore.
+> - **schema**: if you need to perform deepened validation of nested properties, this field allows you to create a nested schema. Schema verification is **recursive**. Any level of nesting is valid, but bear in mind that this will affect the usability of your plugin.
+> - **Any property attached to a configuration object but not present in your schema will also invalidate the said configuration.**
+
+---
+
+#### Examples:
+
+This `schema.lua` file for the [key-auth](/plugins/key-authentication/) plugin defines a default list of accepted parameter names for an API key, and a boolean whose default is set to `false`:
+
+```lua
+-- schema.lua
+return {
+  no_consumer = true,
+  fields = {
+    key_names = {type = "array", required = true, default = {"apikey"}},
+    hide_credentials = {type = "boolean", default = false}
+  }
+}
+```
+
+Hence, when implementing the `access()` function of your plugin in [handler.lua]({{page.book.chapters.custom-logic}}) and given that the user enabled the plugin with the default values, you'd have access to:
+
+```lua
+-- handler.lua
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  print(config.key_names) -- {"apikey"}
+  print(config.hide_credentials) -- false
+end
+
+return CustomHandler
+```
+
+---
+
+A more complex example, which could be used for an eventual logging plugin:
+
+```lua
+-- schema.lua
+
+local function server_port(given_value, given_config)
+  -- Custom validation
+  if given_value > 65534 then
+    return false, "port value too high"
+  end
+
+  -- If environment is "development", 8080 will be the default port
+  if given_config.environment == "development" then
+    return true, nil, {port = 8080}
+  end
+end
+
+return {
+  fields = {
+    environment = {type = "string", required = true, enum = {"production", "development"}}
+    server = {
+      type = "table",
+      schema = {
+        fields = {
+          host = {type = "url", default = "http://example.com"},
+          port = {type = "number", func = server_port, default = 80}
+        }
+      }
+    }
+  }
+}
+```
+
+Such a configuration will allow a user to post the configuration to your plugin as follows:
+
+```bash
+$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+    -d "name=my-custom-plugin" \
+    -d "config.environment=development" \
+    -d "config.server.host=http://localhost"
+```
+
+And the following will be available in [handler.lua]({{page.book.chapters.custom-logic}}):
+
+```lua
+-- handler.lua
+local BasePlugin = require "kong.plugins.base_plugin"
+local CustomHandler = BasePlugin:extend()
+
+function CustomHandler:new()
+  CustomHandler.super.new(self, "my-custom-plugin")
+end
+
+function CustomHandler:access(config)
+  CustomHandler.super.access(self)
+
+  print(config.environment) -- "development"
+  print(config.server.host) -- "http://localhost"
+  print(config.server.port) -- 8080
+end
+
+return CustomHandler
+```
+
+---
+
+Next: [Store custom entities &rsaquo;]({{page.book.next}})
+
+[Admin API]: /docs/{{page.kong_version}}/admin-api

--- a/app/docs/0.14.x/plugin-development/tests.md
+++ b/app/docs/0.14.x/plugin-development/tests.md
@@ -1,0 +1,94 @@
+---
+title: Plugin Development - Writing tests
+book: plugin_dev
+chapter: 9
+---
+
+# {{page.title}}
+
+---
+
+If you are serious about your plugins, you probably want to write tests for it. Unit testing Lua is easy, and [many testing frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you might also want to write integration tests. Again, Kong has your back.
+
+---
+
+### Write integration tests
+
+The preferred testing framework for Kong is [busted](http://olivinelabs.com/busted/) running with the [resty-cli](https://github.com/openresty/resty-cli) interpreter, though you are free to use another one if you wish. In the Kong repository, the busted executable can be found at `bin/busted`.
+
+Kong provides you with a helper to start and stop it from Lua in your test suite: `spec.helpers`. This helper also provides you with ways to insert fixtures in your datastore before running your tests, as well as dropping it, and various other helpers.
+
+If you are writing your plugin in your own repository, you will need to copy the following files until the Kong testing framework is released:
+
+- `bin/busted`: the busted executable running with the resty-cli interpreter
+- `spec/helpers.lua`: helper functions to start/stop Kong from busted
+- `spec/kong_tests.conf`: a configuration file for your running your test Kong instances with the helpers module
+
+Assuming that the `spec.helpers` module is available in your `LUA_PATH`, you can use the following Lua code in busted to start and stop Kong:
+
+```lua
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  describe("my plugin", function()
+
+    local bp = helpers.get_db_utils(strategy)
+
+    setup(function()
+      local service = bp.services:insert {
+        name = "test-service",
+        host = "httpbin.org"
+      }
+
+      bp.routes:insert({
+        hosts = { "test.com" },
+        service = { id = service.id }
+      })
+
+      -- start Kong with your testing Kong configuration (defined in "spec.helpers")
+      assert(helpers.start_kong( { custom_plugins = "my-plugin" }))
+
+      admin_client = helpers.admin_client()
+    end)
+
+    teardown(function()
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+    end)
+
+    describe("thing", function()
+      it("should do thing", function()
+        -- send requests through Kong
+        local res = proxy_client:get("/get", {
+          headers = {
+            ["Host"] = "test.com"
+          }
+        })
+
+        local body = assert.res_status(200, res)
+
+        -- body is a string containing the response
+      end)
+    end)
+  end)
+end
+```
+
+> Reminder: With the test Kong configuration file, Kong is running with its proxy listening on port 8100 and Admin API on port 8101.
+
+---
+
+Next: [Distribute your plugin &rsaquo;]({{page.book.next}})

--- a/app/docs/0.14.x/proxy.md
+++ b/app/docs/0.14.x/proxy.md
@@ -1,0 +1,1133 @@
+---
+title: Proxy Reference
+---
+
+# Proxy Reference
+
+In this document we will cover Kong's **proxying capabilities**  by explaining
+its routing capabilities and internal workings in details.
+
+Kong exposes several interfaces which can be tweaked by two configuration
+properties:
+
+- `proxy_listen`, which defines a list of addresses/ports on which Kong will
+  accept **public traffic** from clients and proxy it to your upstream services
+  (`8000` by default).
+- `admin_listen`, which also defines a list of addresses and ports, but those
+  should be restricted to only be accessed by administrators, as they expose
+  Kong's configuration capabilities: the **Admin API** (`8001` by default).
+
+<div class="alert alert-warning">
+<p><strong>Note:</strong> Starting with 0.13.0, the API entity was
+deprecated. This document will cover proxying with the new Routes and
+Services entities.</p>
+<p>See an older version of this document if you are using 0.12 or
+below.</p>
+</div>
+
+## Table of Contents
+
+- [Terminology][proxy-terminology]
+- [Overview][proxy-overview]
+- [Reminder: How to configure a Service][proxy-reminder]
+- [Routes and matching capabilities][proxy-routes-and-matching-capabilities]
+    - [Request Host header][proxy-request-host-header]
+        - [Using wildcard hostnames][proxy-using-wildcard-hostnames]
+        - [The `preserve_host` property][proxy-preserve-host-property]
+    - [Request path][proxy-request-path]
+        - [Using regexes in paths][proxy-using-regexes-in-paths]
+            - [Evaluation order][proxy-evaluation-order]
+            - [Capturing groups][proxy-capturing-groups]
+            - [Escaping special characters][proxy-escaping-special-characters]
+        - [The `strip_path` property][proxy-strip-path-property]
+    - [Request HTTP method][proxy-request-http-method]
+- [Matching priorities][proxy-matching-priorities]
+- [Proxying behavior][proxy-proxying-behavior]
+    - [1. Load balancing][proxy-load-balancing]
+    - [2. Plugins execution][proxy-plugins-execution]
+    - [3. Proxying & upstream timeouts][proxy-proxying-upstream-timeouts]
+    - [4. Errors & retries][proxy-retries]
+    - [5. Response][proxy-response]
+- [Configuring a fallback Route][proxy-configuring-a-fallback-route]
+- [Configuring SSL for a Route][proxy-configuring-ssl-for-a-route]
+    - [Restricting the client protocol (HTTP/HTTPS)][proxy-restricting-client-protocol]
+- [Proxy WebSocket traffic][proxy-websocket]
+    - [WebSocket and TLS][proxy-websocket-tls]
+- [Conclusion][proxy-conclusion]
+
+[proxy-terminology]: #terminology
+[proxy-overview]: #overview
+[proxy-reminder]: #reminder-how-to-configure-a-service
+[proxy-routes-and-matching-capabilities]: #routes-and-matching-capabilities
+[proxy-request-host-header]: #request-host-header
+[proxy-using-wildcard-hostnames]: #using-wildcard-hostnames
+[proxy-preserve-host-property]: #the-preserve_host-property
+[proxy-request-path]: #request-path
+[proxy-using-regexes-in-paths]: #using-regexes-in-paths
+[proxy-evaluation-order]: #evaluation-order
+[proxy-capturing-groups]: #capturing-groups
+[proxy-escaping-special-characters]: #escaping-special-characters
+[proxy-strip-path-property]: #the-strip_path-property
+[proxy-request-http-method]: #request-http-method
+[proxy-matching-priorities]: #matching-priorities
+[proxy-proxying-behavior]: #proxying-behavior
+[proxy-load-balancing]: #1-load-balancing
+[proxy-plugins-execution]: #2-plugins-execution
+[proxy-proxying-upstream-timeouts]: #3-proxying-upstream-timeouts
+[proxy-retries]: #4-errors-retries
+[proxy-response]: #5-response
+[proxy-configuring-a-fallback-route]: #configuring-a-fallback-route
+[proxy-configuring-ssl-for-a-route]: #configuring-ssl-for-a-route
+[proxy-restricting-client-protocol]: #restricting-the-client-protocol-http-https
+[proxy-websocket]: #proxy-websocket-traffic
+[proxy-websocket-tls]: #websocket-and-tls
+[proxy-conclusion]: #conclusion
+
+## Terminology
+
+- `client`: Refers to the *downstream* client making requests to Kong's
+  proxy port.
+- `upstream service`: Refers to your own API/service sitting behind Kong, to
+  which client requests are forwarded.
+- `Service`: Service entities, as the name implies, are abstractions of each of
+  your own upstream services. Examples of Services would be a data
+  transformation microservice, a billing API, etc.
+- `Route`: This refers to the Kong Routes entity. Routes are entrypoints into
+  Kong, and defining rules for a request to be matched, and routed to a given
+  Service.
+- `Plugin`: This refers to Kong "plugins", which are pieces of business logic
+  that run in the proxying lifecycle. Plugins can be configured through the
+  Admin API - either globally (all incoming traffic) or on specific Routes
+  and Services.
+
+[Back to TOC](#table-of-contents)
+
+## Overview
+
+From a high-level perspective, Kong listens for HTTP traffc on its configured
+proxy port(s) (`8000` and `8443` by default). Kong will evaluate any incoming
+HTTP request against the Routes you have configured and try to find a matching
+one. If a given request matches the rules of a specific Route, Kong will
+process proxying the request. Because each Route is linked to a Service, Kong
+will run the plugins you have configured on your Route and its associated
+Service, and then proxy the request upstream.
+
+You can manage Routes via Kong's Admin API. The `hosts`, `paths`, and `methods`
+attributes of Routes define rules for matching incoming HTTP requests.
+
+If Kong receives a request that it cannot match against any of the configured
+Routes (or if no Routes are configured), it will respond with:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+Server: kong/<x.x.x>
+
+{
+    "message": "no route and no API found with those values"
+}
+```
+
+**Note**: this message mentions "APIs" since for backwards-compatibility
+reasons, Kong 0.13 still supports the API entity (and tries to match a request
+against any configured API if no Route was matched first).
+
+[Back to TOC](#table-of-contents)
+
+## Reminder: How to configure a Service
+
+The [Configuring a Service][configuring-a-service] quickstart guide explains
+how Kong is configured via the [Admin API][API].
+
+Adding a Service to Kong is done by sending an HTTP request to the Admin API:
+
+```
+$ curl -i -X POST http://localhost:8001/services/ \
+    -d 'name=foo-service' \
+    -d 'url=http://foo-service.com'
+HTTP/1.1 201 Created
+...
+
+{
+    "connect_timeout": 60000,
+    "created_at": 1515537771,
+    "host": "foo-service.com",
+    "id": "d54da06c-d69f-4910-8896-915c63c270cd",
+    "name": "foo-service",
+    "path": "/",
+    "port": 80,
+    "protocol": "http",
+    "read_timeout": 60000,
+    "retries": 5,
+    "updated_at": 1515537771,
+    "write_timeout": 60000
+}
+```
+
+This request instructs Kong to register a Service named "foo-service", which
+points to `http://foo-service.com` (your upstream).
+
+**Note:** the `url` argument is a shorthand argument to populate the
+`protocol`, `host`, `port`, and `path` attributes at once.
+
+Now, in order to send traffic to this Service through Kong, we need to specify
+a Route, which acts as an entrypoint to Kong:
+
+```
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -d 'hosts[]=example.com' \
+    -d 'paths[]=/foo' \
+    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+HTTP/1.1 201 Created
+...
+
+{
+    "created_at": 1515539858,
+    "hosts": [
+        "example.com"
+    ],
+    "id": "ee794195-6783-4056-a5cc-a7e0fde88c81",
+    "methods": null,
+    "paths": [
+        "/foo"
+    ],
+    "preserve_host": false,
+    "priority": 0,
+    "protocols": [
+        "http",
+        "https"
+    ],
+    "service": {
+        "id": "d54da06c-d69f-4910-8896-915c63c270cd"
+    },
+    "strip_path": true,
+    "updated_at": 1515539858
+}
+```
+
+We have now configured a Route to match incoming requests matching the given
+`hosts` and `paths`, and forward them to the `foo-service` we configured, thus
+proxying this traffic to `http://foo-service.com`.
+
+Kong is a transparent proxy, and it will by default forward the request to your
+upstream service untouched, with the exception of various headers such as
+`Connection`, `Date`, and others as required by the HTTP specifications.
+
+[Back to TOC](#table-of-contents)
+
+## Routes and matching capabilities
+
+Let's now discuss how Kong matches a request against the configured `hosts`,
+`paths` and `methods` properties (or fields) of a Route. Note that all three of
+these fields are **optional**, but at least **one of them** must be specified.
+
+For a request to match a Route:
+
+- The request **must** include **all** of the configured fields
+- The values of the fields in the request **must** match at least one of the
+  configured values (While the field configurations accepts one or more values,
+  a request needs only one of the values to be considered a match)
+
+Let's go through a few examples. Consider a Route configured like this:
+
+```json
+{
+    "hosts": ["example.com", "foo-service.com"],
+    "paths": ["/foo", "/bar"],
+    "methods": ["GET"]
+}
+```
+
+Some of the possible requests matching this Route would look like:
+
+```http
+GET /foo HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /bar HTTP/1.1
+Host: foo-service.com
+```
+
+```http
+GET /foo/hello/world HTTP/1.1
+Host: example.com
+```
+
+All three of these requests satisfy all the conditions set in the Route
+definition.
+
+However, the following requests would **not** match the configured conditions:
+
+```http
+GET / HTTP/1.1
+Host: example.com
+```
+
+```http
+POST /foo HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /foo HTTP/1.1
+Host: foo.com
+```
+
+All three of these requests satisfy only two of configured conditions. The
+first request's path is not a match for any of the configured `paths`, same for
+the second request's HTTP method, and the third request's Host header.
+
+Now that we understand how the `hosts`, `paths`, and `methods` properties work
+together, let's explore each property individually.
+
+[Back to TOC](#table-of-contents)
+
+### Request Host header
+
+Routing a request based on its Host header is the most straightforward way to
+proxy traffic through Kong, especially since this is the intended usage of the
+HTTP Host header. Kong makes it easy to do via the `hosts` field of the Route
+entity.
+
+`hosts` accepts multiple values, which must be comma-separated when specifying
+them via the Admin API:
+
+`hosts` accepts multiple values, which is straightforward to represent in a
+JSON payload:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -H 'Content-Type: application/json' \
+    -d '{"hosts":["example.com", "foo-service.com"]}'
+HTTP/1.1 201 Created
+...
+```
+
+But since the Admin API also supports form-urlencoded content types, you
+can specify an array via the `[]` notation:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes/ \
+    -d 'hosts[]=example.com' \
+    -d 'hosts[]=foo-service.com'
+HTTP/1.1 201 Created
+...
+```
+
+To satisfy the `hosts` condition of this Route, any incoming request from a
+client must now have its Host header set to one of:
+
+```
+Host: example.com
+```
+
+or:
+
+```
+Host: foo-service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+#### Using wildcard hostnames
+
+To provide flexibility, Kong allows you to specify hostnames with wildcards in
+the `hosts` field. Wildcard hostnames allow any matching Host header to satisfy
+the condition, and thus match a given Route.
+
+Wildcard hostnames **must** contain **only one** asterisk at the leftmost
+**or** rightmost label of the domain. Examples:
+
+- `*.example.com` would allow Host values such as `a.example.com` and
+  `x.y.example.com` to match.
+- `example.*` would allow Host values such as `example.com` and `example.org`
+  to match.
+
+A complete example would look like this:
+
+```json
+{
+    "hosts": ["*.example.com", "service.com"]
+}
+```
+
+Which would allow the following requests to match this Route:
+
+```http
+GET / HTTP/1.1
+Host: an.example.com
+```
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+#### The `preserve_host` property
+
+When proxying, Kong's default behavior is to set the upstream request's Host
+header to the hostname specified in the Service's `host`. The
+`preserve_host` field accepts a boolean flag instructing Kong not to do so.
+
+For example, when the `preserve_host` property is not changed and a Route is
+configured like so:
+
+```json
+{
+    "hosts": ["service.com"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+A possible request from a client to Kong could be:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+Kong would extract the Host header value from the Service's `host` property, ,
+and would send the following upstream request:
+
+```http
+GET / HTTP/1.1
+Host: <my-service-host.com>
+```
+
+However, by explicitly configuring a Route with `preserve_host=true`:
+
+```json
+{
+    "hosts": ["service.com"],
+    "preserve_host": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+And assuming the same request from the client:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+Kong would preserve the Host on the client request and would send the following
+upstream request instead:
+
+```http
+GET / HTTP/1.1
+Host: service.com
+```
+
+[Back to TOC](#table-of-contents)
+
+### Request path
+
+Another way for a Route to be matched is via request paths. To satisfy this
+routing condition, a client request's path **must** be prefixed with one of the
+values of the `paths` attribute.
+
+For example, with a Route configured like so:
+
+```json
+{
+    "paths": ["/service", "/hello/world"]
+}
+```
+
+The following requests would be matched:
+
+```http
+GET /service HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /service/resource?param=value HTTP/1.1
+Host: example.com
+```
+
+```http
+GET /hello/world/resource HTTP/1.1
+Host: anything.com
+```
+
+For each of these requests, Kong detects that their URL path is prefixed with
+one of the Routes's `paths` values. By default, Kong would then proxy the
+request upstream without changing the URL path.
+
+When proxying with path prefixes, **the longest paths get evaluated first**.
+This allow you to define two Routes with two paths: `/service` and
+`/service/resource`, and ensure that the former does not "shadow" the latter.
+
+[Back to TOC](#table-of-contents)
+
+#### Using regexes in paths
+
+Kong supports regular expression pattern matching for an Route's `paths` field
+via [PCRE](http://pcre.org/) (Perl Compatible Regular Expression). You can
+assign paths as both prefixes and regexes to a Route at the same time.
+
+For example, if we consider the following Route:
+
+```json
+{
+    "paths": ["/users/\d+/profile", "/following"]
+}
+```
+
+The following requests would be matched by this Route:
+
+```http
+GET /following HTTP/1.1
+Host: ...
+```
+
+```http
+GET /users/123/profile HTTP/1.1
+Host: ...
+```
+
+The provided regexes are evaluated with the `a` PCRE flag (`PCRE_ANCHORED`),
+meaning that they will be constrained to match at the first matching point
+in the path (the root `/` character).
+
+[Back to TOC](#table-of-contents)
+
+##### Evaluation order
+
+As previously mentioned, Kong evaluates prefix paths by length: the longest
+prefix paths are evaluated first. However, Kong will evaluate regex paths based
+on the `regex_priority` attribute of Routes. This means that considering
+the following Routes:
+
+```json
+[
+    {
+        "paths": ["/status/\d+"],
+        "regex_priority": 0
+    },
+    {
+        "paths": ["/version/\d+/status/\d+"],
+        "regex_priority": 6
+    },
+    {
+        "paths": ["/version"],
+        "regex_priority": 3
+    },
+]
+```
+
+In this scenario, Kong will evaluate incoming requests against the following
+defined URIs, in this order:
+
+1. `/version`
+2. `/version/\d+/status/\d+`
+3. `/status/\d+`
+
+Prefix paths are always evaluated first.
+
+As usual, a request must still match a Route's `hosts` and `methods` properties
+as well, and Kong will traverse your Routes until it finds one that matches
+the most rules (see [Routing priorities][proxy-routing-priorities]).
+
+[Back to TOC](#table-of-contents)
+
+##### Capturing groups
+
+Capturing groups are also supported, and the matched group will be extracted
+from the path and available for plugins consumption. If we consider the
+following regex:
+
+```
+/version/(?<version>\d+)/users/(?<user>\S+)
+```
+
+And the following request path:
+
+```
+/version/1/users/john
+```
+
+Kong will consider the request path a match, and if the overall Route is
+matched (considering the `hosts` and `methods` fields), the extracted capturing
+groups will be available from the plugins in the `ngx.ctx` variable:
+
+```lua
+local router_matches = ngx.ctx.router_matches
+
+-- router_matches.uri_captures is:
+-- { "1", "john", version = "1", user = "john" }
+```
+
+[Back to TOC](#table-of-contents)
+
+##### Escaping special characters
+
+Next, it is worth noting that characters found in regexes are often
+reserved characters according to
+[RFC 3986](http://www.gbiv.com/protocols/uri/rfc/rfc3986.html) and as such,
+should be percent-encoded. **When configuring Routes with regex paths via the
+Admin API, be sure to URL encode your payload if necessary**. For example,
+with `curl` and using an `application/x-www-form-urlencoded` MIME type:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes \
+    --data-urlencode 'uris[]=/status/\d+'
+HTTP/1.1 201 Created
+...
+```
+
+Note that `curl` does not automatically URL encode your payload, and note the
+usage of `--data-urlencode`, which prevents the `+` character to be URL decoded
+and interpreted as a space ` ` by Kong's Admin API.
+
+[Back to TOC](#table-of-contents)
+
+#### The `strip_path` property
+
+It may be desirable to specify a path prefix to match a Route, but not
+include it in the upstream request. To do so, use the `strip_path` boolean
+property by configuring a Route like so:
+
+```json
+{
+    "paths": ["/service"],
+    "strip_path": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Enabling this flag instructs Kong that when matching this Route, and proceeding
+with the proxying to a Service, it should **not** include the matched part of
+the URL path in the upstream request's URL. For example, the following
+client's request to the above Route:
+
+```http
+GET /service/path/to/resource HTTP/1.1
+Host: ...
+```
+
+Will cause Kong to send the following upstream request:
+
+```http
+GET /path/to/resource HTTP/1.1
+Host: ...
+```
+
+The same way, if a regex path is defined on a Route that has `strip_path`
+enabled, the entirety of the request URL matching sequence will be stripped.
+Example:
+
+```json
+{
+    "paths": ["/version/\d+/service"],
+    "strip_path": true,
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+The following HTTP request matching the provided regex path:
+
+```http
+GET /version/1/service/path/to/resource HTTP/1.1
+Host: ...
+```
+
+Will be proxied upstream by Kong as:
+
+```http
+GET /path/to/resource HTTP/1.1
+Host: ...
+```
+
+[Back to TOC](#table-of-contents)
+
+### Request HTTP method
+
+The `methods` field allows matching the requests depending on their HTTP
+method.  It accepts multiple values. Its default value is empty (the HTTP
+method is not used for routing).
+
+The following Route allows routing via `GET` and `HEAD`:
+
+```json
+{
+    "methods": ["GET", "HEAD"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Such a Route would be matched with the following requests:
+
+```http
+GET / HTTP/1.1
+Host: ...
+```
+
+```http
+HEAD /resource HTTP/1.1
+Host: ...
+```
+
+But it would not match a `POST` or `DELETE` request. This allows for much more
+granularity when configuring plugins on Routes. For example, one could imagine
+two Routes pointing to the same service: one with unlimited unauthenticated
+`GET` requests, and a second one allowing only authenticated and rate-limited
+`POST` requests (by applying the authentication and rate limiting plugins to
+such requests).
+
+[Back to TOC](#table-of-contents)
+
+## Matching priorities
+
+A Route may define matching rules based on its `hosts`, `paths`, and `methods`
+fields. For Kong to match an incoming request to a Route, all existing fields
+must be satisfied. However, Kong allows for quite some flexibility by allowing
+two or more Routes to be configured with fields containing the same values -
+when this occurs, Kong applies a priority rule.
+
+The rule is: **when evaluating a request, Kong will first try to match the
+Routes with the most rules**.
+
+For example, if two Routes are configured like so:
+
+```json
+{
+    "hosts": ["example.com"],
+    "service": {
+        "id": "..."
+    }
+},
+{
+    "hosts": ["example.com"],
+    "methods": ["POST"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+The second Route has a `hosts` field **and** a `methods` field, so it will be
+evaluated first by Kong. By doing so, we avoid the first Route "shadowing"
+calls intended for the second one.
+
+Thus, this request will match the first Route
+
+```http
+GET / HTTP/1.1
+Host: example.com
+```
+
+And this request will match the second one:
+
+```http
+POST / HTTP/1.1
+Host: example.com
+```
+
+Following this logic, if a third Route was to be configured with a `hosts`
+field, a `methods` field, and a `uris` field, it would be evaluated first by
+Kong.
+
+[Back to TOC](#table-of-contents)
+
+## Proxying behavior
+
+The proxying rules above detail how Kong forwards incoming requests to your
+upstream services. Below, we detail what happens internally between the time
+Kong *matches* an HTTP request with a registered Route, and the actual
+*forwarding* of the request.
+
+[Back to TOC](#table-of-contents)
+
+### 1. Load balancing
+
+Kong implements load balancing capabilities to distribute proxied
+requests across a pool of instances of an upstream service.
+
+You can find more information about configuring load balancing by consulting
+the [Load Balancing Reference][load-balancing-reference].
+
+[Back to TOC](#table-of-contents)
+
+### 2. Plugins execution
+
+Kong is extensible via "plugins" that hook themselves in the request/response
+lifecycle of the proxied requests. Plugins can perform a variety of operations
+in your environment and/or transformations on the proxied request.
+
+Plugins can be configured to run globally (for all proxied traffic) or on
+specific Routes and Services. In both cases, you must create a [plugin
+configuration][plugin-configuration-object] via the Admin API.
+
+Once a Route has been matched (and its associated Service entity), Kong will
+run plugins associated to either of those entities. Plugins configured on a
+Route run before plugins configured on a Service, but otherwise, the usual
+rules of [plugins association][plugin-association-rules] apply.
+
+These configured plugins will run their `access` phase, which you can find more
+information about in the [Plugin development guide][plugin-development-guide].
+
+[Back to TOC](#table-of-contents)
+
+### 3. Proxying & upstream timeouts
+
+Once Kong has executed all the necessary logic (including plugins), it is ready
+to forward the request to your upstream service. This is done via Nginx's
+[ngx_http_proxy_module][ngx-http-proxy-module]. You can configure the desired
+timeouts for the connection between Kong and a given upstream, via the following
+properties of a Service:
+
+- `upstream_connect_timeout`: defines in milliseconds the timeout for
+  establishing a connection to your upstream service. Defaults to `60000`.
+- `upstream_send_timeout`: defines in milliseconds a timeout between two
+  successive write operations for transmitting a request to your upstream
+  service.  Defaults to `60000`.
+- `upstream_read_timeout`: defines in milliseconds a timeout between two
+  successive read operations for receiving a request from your upstream
+  service.  Defaults to `60000`.
+
+Kong will send the request over HTTP/1.1, and set the following headers:
+
+- `Host: <your_upstream_host>`, as previously described in this document.
+- `Connection: keep-alive`, to allow for reusing the upstream connections.
+- `X-Real-IP: <remote_addr>`, where `$remote_addr` is the variable bearing
+  the same name provided by
+  [ngx_http_core_module][ngx-remote-addr-variable]. Please note that the
+  `$remote_addr` is likely overridden by
+  [ngx_http_realip_module][ngx-http-realip-module].
+- `X-Forwarded-For: <address>`, where `<address>` is the content of
+  `$realip_remote_addr` provided by
+  [ngx_http_realip_module][ngx-http-realip-module] appended to the request
+  header with the same name.
+- `X-Forwarded-Proto: <protocol>`, where `<protocol>` is the protocol used by
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise, the value of the `$scheme` variable provided by
+  [ngx_http_core_module][ngx-scheme-variable] will be used.
+- `X-Forwarded-Host: <host>`, where `<host>` is the host name sent by
+  the client. In the case where `$realip_remote_addr` is one of the **trusted**
+  addresses, the request header with the same name gets forwarded if provided.
+  Otherwise, the value of the `$host` variable provided by
+  [ngx_http_core_module][ngx-host-variable] will be used.
+- `X-Forwarded-Port: <port>`, where `<port>` is the port of the server which
+  accepted a request. In the case where `$realip_remote_addr` is one of the
+  **trusted** addresses, the request header with the same name gets forwarded
+  if provided. Otherwise, the value of the `$server_port` variable provided by
+  [ngx_http_core_module][ngx-server-port-variable] will be used.
+
+All the other request headers are forwarded as-is by Kong.
+
+One exception to this is made when using the WebSocket protocol. If so, Kong
+will set the following headers to allow for upgrading the protocol between the
+client and your upstream services:
+
+- `Connection: Upgrade`
+- `Upgrade: websocket`
+
+More information on this topic is covered in the
+[Proxy WebSocket traffic][proxy-websocket] section.
+
+[Back to TOC](#table-of-contents)
+
+### 4. Errors & retries
+
+Whenever an error occurs during proxying, Kong will use the underlying
+Nginx [retries][ngx-http-proxy-retries] mechanism to pass the request on to
+the next upstream.
+
+There are two configurable elements here:
+
+1. The number of retries: this can be configured per Service using the
+   `retries` property. See the [Admin API][API] for more details on this.
+
+2. What exactly constitutes an error: here Kong uses the Nginx defaults, which
+   means an error or timeout occuring while establishing a connection with the
+   server, passing a request to it, or reading the response headers.
+
+The second option is based on Nginx's
+[proxy_next_upstream][proxy_next_upstream] directive. This option is not
+directly configurable through Kong, but can be added using a custom Nginx
+configuration. See the [configuration reference][configuration-reference] for
+more details.
+
+[Back to TOC](#table-of-contents)
+
+### 5. Response
+
+Kong receives the response from the upstream service and sends it back to the
+downstream client in a streaming fashion. At this point Kong will execute
+subsequent plugins added to the Route and/or Service that implement a hook in
+the `header_filter` phase.
+
+Once the `header_filter` phase of all registered plugins has been executed, the
+following headers will be added by Kong and the full set of headers be sent to
+the client:
+
+- `Via: kong/x.x.x`, where `x.x.x` is the Kong version in use
+- `X-Kong-Proxy-Latency: <latency>`, where `latency` is the time in milliseconds
+  between Kong receiving the request from the client and sending the request to
+  your upstream service.
+- `X-Kong-Upstream-Latency: <latency>`, where `latency` is the time in
+  milliseconds that Kong was waiting for the first byte of the upstream service
+  response.
+
+Once the headers are sent to the client, Kong will start executing
+registered plugins for the Route and/or Service that implement the
+`body_filter` hook. This hook may be called multiple times, due to the
+streaming nature of Nginx. Each chunk of the upstream response that is
+successfully processed by such `body_filter` hooks is sent back to the client.
+You can find more informations about the `body_filter` hook in the [Plugin
+development guide][plugin-development-guide].
+
+[Back to TOC](#table-of-contents)
+
+## Configuring a fallback Route
+
+As a practical use-case and example of the flexibility offered by Kong's
+proxying capabilities, let's try to implement a "fallback Route", so that in
+order to avoid Kong responding with an HTTP `404`, "no route found", we can
+catch such requests and proxy them to a special upstream service, or apply a
+plugin to it (such a plugin could, for example, terminate the request with a
+different status code or response without proxying the request).
+
+Here is an example of such a fallback Route:
+
+```json
+{
+    "paths": ["/"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+As you can guess, any HTTP request made to Kong would actually match this
+Route, since all URIs are prefixed by the root character `/`. As we know from
+the [Request path][proxy-request-path] section, the longest URL paths are
+evaluated first by Kong, so the `/` path will eventually be evaluated last by
+Kong, and effectively provide a "fallback" Route, only matched as a last
+resort. You can then send traffic to a special Service or apply any plugin you
+wish on this Route.
+
+[Back to TOC](#table-of-contents)
+
+## Configuring SSL for a Route
+
+Kong provides a way to dynamically serve SSL certificates on a per-connection
+basis. SSL certificates are directly handled by the core, and configurable via
+the Admin API. Clients connecting to Kong over TLS must support the [Server
+Name Indication][SNI] extension to make use of this feature.
+
+SSL certificates are handled by two resources in the Kong Admin API:
+
+- `/certificates`, which stores your keys and certificates.
+- `/snis`, which associates a registered certificate with a Server Name
+  Indication.
+
+You can find the documentation for those two resources in the
+[Admin API Reference][API].
+
+Here is how to configure an SSL certificate on a given Route: first, upload
+your SSL certificate and key via the Admin API:
+
+```bash
+$ curl -i -X POST http://localhost:8001/certificates \
+    -F "cert=@/path/to/cert.pem" \
+    -F "key=@/path/to/cert.key" \
+    -F "snis=ssl-example.com,other-ssl-example.com"
+HTTP/1.1 201 Created
+...
+```
+
+The `snis` form parameter is a sugar parameter, directly inserting an SNI and
+associating the uploaded certificate to it.
+
+You must now register the following Route within Kong. We will match requests
+to this Route using only the Host header for convenience:
+
+```bash
+$ curl -i -X POST http://localhost:8001/routes \
+    -d 'hosts=ssl-example.com,other-ssl-example.com' \
+    -d 'service.id=d54da06c-d69f-4910-8896-915c63c270cd'
+HTTP/1.1 201 Created
+...
+```
+
+You can now expect the Route to be served over HTTPS by Kong:
+
+```bash
+$ curl -i https://localhost:8443/ \
+  -H "Host: ssl-example.com"
+HTTP/1.1 200 OK
+...
+```
+
+When establishing the connection and negotiating the SSL handshake, if your
+client sends `ssl-example.com` as part of the SNI extension, Kong will serve
+the `cert.pem` certificate previously configured.
+
+[Back to TOC](#table-of-contents)
+
+### Restricting the client protocol (HTTP/HTTPS)
+
+Routes have a `protocols` property to restrict the client protocol they should
+listen for. This attribute accepts a set of values, which can be `http` or
+`https`.
+
+A Route with `http` and `https` will accept traffic regardless of the protocol
+the client is connecting with (plain-text or over TLS):
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["http", "https"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+Not specifying `https` has the same effect, a route would accept both
+plain-text and TLS traffic:
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["http"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+However, a Route with only `https` would _only_ accept traffic over TLS. It
+would _also_ accept unencrypted traffic _if_ SSL termination previously
+occurred from a trusted IP. SSL termination is considered valid when the
+request comes from one of the configured IPs in
+[trusted_ips][configuration-trusted-ips] and if the `X-Forwarded-Proto: https`
+header is set:
+
+```json
+{
+    "hosts": ["..."],
+    "paths": ["..."],
+    "methods": ["..."],
+    "protocols": ["https"],
+    "service": {
+        "id": "..."
+    }
+}
+```
+
+If a Route such as the above matches a request, but that request is in
+plain-text without valid prior SSL termination, Kong responds with:
+
+```http
+HTTP/1.1 426 Upgrade Required
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: Upgrade
+Upgrade: TLS/1.2, HTTP/1.1
+Server: kong/x.y.z
+
+{"message":"Please use HTTPS protocol"}
+```
+
+[Back to TOC](#table-of-contents)
+
+## Proxy WebSocket traffic
+
+Kong supports WebSocket traffic thanks to the underlying Nginx implementation.
+When you wish to establish a WebSocket connection between a client and your
+upstream services *through* Kong, you must establish a WebSocket handshake.
+This is done via the HTTP Upgrade mechanism. This is what your client request
+made to Kong would look like:
+
+```http
+GET / HTTP/1.1
+Connection: Upgrade
+Host: my-websocket-api.com
+Upgrade: WebSocket
+```
+
+This will make Kong forward the `Connection` and `Upgrade` headers to your
+upstream service, instead of dismissing them due to the hop-by-hop nature of a
+standard HTTP proxy.
+
+[Back to TOC](#table-of-contents)
+
+### WebSocket and TLS
+
+Kong will accept `ws` and `wss` connections on its respective `http` and
+`https` ports. To enforce TLS connections from clients, set the `protocols`
+property of the [Route][route-entity] to `https` only.
+
+When setting up the [Service][service-entity] to point to your upstream
+WebSocket service, you should carefully pick the protocol you want to use
+between Kong and the upstream. If you want to use TLS (`wss`), then the
+upstream WebSocket service must be defined using the `https` protocol in the
+Service `protocol` property, and the proper port (usually 443). To connect
+without TLS (`ws`), then the `http` protocol and port (usually 80) should be
+used in `protocol` instead.
+
+If you want Kong to terminate SSL/TLS, you can accept `wss` only from the
+client, but proxy to the upstream service over plain text, or `ws`.
+
+[Back to TOC](#table-of-contents)
+
+## Conclusion
+
+Through this guide, we hope you gained knowledge of the underlying proxying
+mechanism of Kong, from how does a request match a Route to be routed to its
+associated Service, on to how to allow for using the WebSocket protocol or
+setup dynamic SSL certificates.
+
+This website is Open-Source and can be found at
+[github.com/Mashape/getkong.org](https://github.com/Mashape/getkong.org/).
+Feel free to provide feedback to this document there, or propose improvements!
+
+If you haven't already, we suggest that you also read the [Load balancing
+Reference][load-balancing-reference], as it closely relates to the topic we
+just covered.
+
+[Back to TOC](#table-of-contents)
+
+[plugin-configuration-object]: /docs/{{page.kong_version}}/admin-api#plugin-object
+[plugin-development-guide]: /docs/{{page.kong_version}}/plugin-development
+[plugin-association-rules]: /docs/{{page.kong_version}}/admin-api/#precedence
+[load-balancing-reference]: /docs/{{page.kong_version}}/loadbalancing
+[configuration-reference]: /docs/{{page.kong_version}}/configuration-reference
+[configuration-trusted-ips]: /docs/{{page.kong_version}}/configuration/#trusted_ips
+[configuring-a-service]: /docs/{{page.kong_version}}/getting-started/configuring-a-service
+[API]: /docs/{{page.kong_version}}/admin-api
+[service-entity]: /docs/{{page.kong_version}}/admin-api/#add-service
+[route-entity]: /docs/{{page.kong_version}}/admin-api/#add-route
+
+[ngx-http-proxy-module]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html
+[ngx-http-realip-module]: http://nginx.org/en/docs/http/ngx_http_realip_module.html
+[ngx-remote-addr-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_remote_addr
+[ngx-scheme-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_scheme
+[ngx-host-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host
+[ngx-server-port-variable]: http://nginx.org/en/docs/http/ngx_http_core_module.html#var_server_port
+[ngx-http-proxy-retries]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries
+[SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication

--- a/app/docs/0.14.x/secure-admin-api.md
+++ b/app/docs/0.14.x/secure-admin-api.md
@@ -1,0 +1,168 @@
+---
+title: Securing the Admin API
+---
+
+# Securing the Admin API
+
+Kong's Admin API provides a RESTful interface for administration and
+configuration of Services, Routes, Plugins, Consumers, and Credentials. Because this
+API allows full control of Kong, it is important to secure this API against
+unwanted access. This document describes a few possible approaches to securing
+the Admin API.
+
+## Table of Contents
+
+- [Network Layer Access Restrictions](#network-layer-access-restrictions)
+  - [Minimal Listening Footprint](#minimal-listening-footprint)
+  - [Layer 3/4 Network Controls](#layer-3-4-network-controls)
+- [Kong API Loopback](#kong-api-loopback)
+- [Custom Nginx Configuration](#custom-nginx-configuration)
+- [Role Based Access Control (RBAC)](#role-based-access-control)
+
+## Network Layer Access Restrictions
+
+### Minimal Listening Footprint
+
+By default since its 0.12.0 release, Kong will only accept requests from the
+local interface, as specified in its default `admin_listen` value:
+
+```
+admin_listen = 127.0.0.1:8001
+```
+
+If you change this value, always ensure to keep the listening footprint to a
+minimum, in order to avoid exposing your Admin API to third-parties, which
+could seriously compromise the security of your Kong cluster as a whole.
+For example, **avoid binding Kong to all of your interfaces**, by using
+values such as `0.0.0.0:8001`.
+
+[Back to TOC](#table-of-contents)
+
+### Layer 3/4 Network Controls
+
+In cases where the Admin API must be exposed beyond a localhost interface,
+network security best practices dictate that network-layer access be restricted
+as much as possible. Consider an environment in which Kong listens on a private
+network interface, but should only be accessed by a small subset of an IP range.
+In such a case, host-based firewalls (e.g. iptables) are useful in limiting
+input traffic ranges. For example:
+
+
+```bash
+# assume that Kong is listening on the address defined below, as defined as a
+# /24 CIDR block, and only a select few hosts in this range should have access
+
+$ grep admin_listen /etc/kong/kong.conf
+admin_listen 10.10.10.3:8001
+
+# explicitly allow TCP packets on port 8001 from the Kong node itself
+# this is not necessary if Admin API requests are not sent from the node
+$ iptables -A INPUT -s 10.10.10.3 -m tcp -p tcp --dport 8001 -j ACCEPT
+
+# explicitly allow TCP packets on port 8001 from the following addresses
+$ iptables -A INPUT -s 10.10.10.4 -m tcp -p tcp --dport 8001 -j ACCEPT
+$ iptables -A INPUT -s 10.10.10.5 -m tcp -p tcp --dport 8001 -j ACCEPT
+
+# drop all TCP packets on port 8001 not in the above IP list
+$ iptables -A INPUT -m tcp -p tcp --dport 8001 -j DROP
+
+```
+
+Additional controls, such as similar ACLs applied at a network device level, are
+encouraged, but fall outside the scope of this document.
+
+[Back to TOC](#table-of-contents)
+
+## Kong API Loopback
+
+Kong's routing design allows it to serve as a proxy for the Admin API itself. In
+this manner, Kong itself can be used to provide fine-grained access control to
+the Admin API. Such an environment requires bootstrapping a new Service that defines
+the `admin_listen` address as the Service's `url`. For example:
+
+```bash
+# assume that Kong has defined admin_listen as 127.0.0.1:8001, and we want to
+# reach the Admin API via the url `/admin-api`
+
+$ curl -X POST http://localhost:8001/services \
+  --data name=admin-api \
+  --data host=localhost \
+  --data port=8001
+
+$ curl -X POST http://localhost:8001/services/admin-api/routes \
+  --data paths[]=/admin-api
+  
+# we can now transparently reach the Admin API through the proxy server
+$ curl localhost:8000/admin-api/apis
+{
+   "data":[
+      {
+         "uris":[
+            "\/admin-api"
+         ],
+         "id":"653b21bd-4d81-4573-ba00-177cc0108dec",
+         "upstream_read_timeout":60000,
+         "preserve_host":false,
+         "created_at":1496351805000,
+         "upstream_connect_timeout":60000,
+         "upstream_url":"http:\/\/localhost:8001",
+         "strip_uri":true,
+         "https_only":false,
+         "name":"admin-api",
+         "http_if_terminated":true,
+         "upstream_send_timeout":60000,
+         "retries":5
+      }
+   ],
+   "total":1
+}
+```
+
+From here, simply apply desired Kong-specific security controls (such as
+[basic][basic-auth] or [key authentication][key-auth],
+[IP restrictions][ip-restriction], or [access control lists][acl]) as you would
+normally to any other Kong API.
+
+[Back to TOC](#table-of-contents)
+
+## Custom Nginx Configuration
+
+Kong is tightly coupled with Nginx as an HTTP daemon, and can thus be integrated
+into environments with custom Nginx configurations. In this manner, use cases
+with complex security/access control requirements can use the full power of
+Nginx/OpenResty to build server/location blocks to house the Admin API as
+necessary. This allows such environments to leverage native Nginx authorization
+and authentication mechanisms, ACL modules, etc., in addition to providing the
+OpenResty environment on which custom/complex security controls can be built.
+
+For more information on integrating Kong into custom Nginx configurations, see
+[Custom Nginx configuration & embedding Kong][custom-configuration].
+
+[Back to TOC](#table-of-contents)
+
+## Role Based Access Control ##
+
+<div class="alert alert-warning">
+  <strong>Enterprise-Only</strong> This feature is only available with an
+  Enterprise Subscription.
+</div>
+
+Enterprise users can configure role-based access control to secure access to the
+Admin API. RBAC allows for fine-grained control over resource access based on
+a model of user roles and permissions. Users are assigned to one or more roles,
+which each in turn possess one or more permissions granting or denying access
+to a particular resource. In this way, fine-grained control over specific Admin
+API resources can be enforced, while scaling to allow complex, case-specific
+uses.
+
+If you are not a Mashape Enterprise customer, you can inquire about our
+Enterprise offering by [contacting us](/enterprise).
+
+[Back to TOC](#table-of-contents)
+
+
+[acl]: /plugins/acl
+[basic-auth]: /plugins/basic-authentication/
+[custom-configuration]: /docs/{{page.kong_version}}/configuration/#custom-nginx-configuration
+[ip-restriction]: /plugins/ip-restriction
+[key-auth]: /plugins/key-authentication


### PR DESCRIPTION
This PR documents changes that are currently happening on the `next` branch in Kong, in which we moved SSL certificates from the old DAO to the new one.

Summary of changes:

* `ssl_certificate_id` field renamed to `certificate_id`
* Slight change in the way the `snis` pseudo attribute works on `/certificates` (previously it could be a string, now it must be an array)
* `PUT` changes in both `/certificates` and `/snis`
* snis have now a primary key `id` (a UUID). The `name` field is indexed but not the primary key any more.
* because of the previous change, a lot of endpoint now accept `name or id` instead of just `name`.