### PR TITLE
fix(ee/docker-install) correct minor discrepancy

### DIFF
--- a/app/docs/enterprise/0.32-x/installation/docker.md
+++ b/app/docs/enterprise/0.32-x/installation/docker.md
@@ -21,7 +21,7 @@ A guide to installing Kong Enterprise Edition (and its license file) as a Docker
     For **trial users**, run the following, replacing `<your trial image URL>` with the URL you received in your welcome email:
 
         curl -Lsv "<your trial image URL>" -o /tmp/kong-docker-ee.tar.gz
-        docker load -i /tmp/kong-docker-ee.tar
+        docker load -i /tmp/kong-docker-ee.tar.gz
 
 
     Now you have the docker image for EE locally this way


### PR DESCRIPTION
### Summary

Fix mismatch between tar/tar.gz in install steps. Both are now tar.gz, as that's what we deliver from Bintray.

- [x] [Commit message & atomicity](https://github.com/Kong/getkong.org/blob/master/CONTRIBUTING.md#commit-atomicity) checked
- [x] Documentation <!-- Adding a new feature? Do you need to document it the README.md or otherwise? -->
- [x] Spellchecked my updates
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->