### PR TITLE
doc(ee/plugins) add links to detail documentation

### DIFF
--- a/app/plugins/ee-canary-release.md
+++ b/app/plugins/ee-canary-release.md
@@ -7,7 +7,8 @@ header_btn_text: Report Bug
 header_btn_href: mailto:support@konghq.com?subject={{ page.header_title }} Plugin Bug
 breadcrumbs:
   Plugins: /plugins
-description:
+description: |
   Reduce the risk of introducing a new software version in production by slowly rolling out the change to a small subset of users. This plugin also enables roll back to your original upstream service, or shift all traffic to the new version.
 
+  * [Detailed documentation for the EE Canary Release Plugin](/docs/enterprise/latest/plugins/canary-release/)
 ---

--- a/app/plugins/ee-forward-proxy.md
+++ b/app/plugins/ee-forward-proxy.md
@@ -11,4 +11,5 @@ breadcrumbs:
 description: |
   The Forward Proxy plugin allows Kong to connect to intermediary transparent HTTP proxies, instead of directly to the upstream_url, when forwarding requests upstream. This is useful in environments where Kong sits in an organization's internal network, the upstream API is available via the public internet, and the organization proxies all outbound traffic through a forward proxy server.
 
+  * [Detailed documentation for the EE Forward Proxy Plugin](/docs/enterprise/latest/plugins/forward-proxy/)
 ---

--- a/app/plugins/ee-oauth2-introspection.md
+++ b/app/plugins/ee-oauth2-introspection.md
@@ -16,4 +16,5 @@ description: |
   the Consumer already has an access token that will be validated against a
   third-party OAuth 2.0 server.
 
+  * [Detailed documentation for the EE OAuth 2.0 Introspection Plugin](/docs/enterprise/latest/plugins/oauth2-introspection/)
 ---

--- a/app/plugins/ee-openid-connect.md
+++ b/app/plugins/ee-openid-connect.md
@@ -15,6 +15,8 @@ description: |
   server (RS) and / or as an OpenID Connect relying party (RP) between the client
   and the upstream service.
 
+  * [Detailed documentation for the EE OpenID Connect Plugin](/docs/enterprise/latest/plugins/openid-connect/)
+
   The plugin supports several types of credentials, including:
 
   - Signed [JWT][jwt] access tokens ([JWS][jws]) with the standardized signing algorithms ([JWA][jwa])

--- a/app/plugins/ee-proxy-caching.md
+++ b/app/plugins/ee-proxy-caching.md
@@ -11,4 +11,5 @@ breadcrumbs:
 description: |
   The Proxy Caching plugin for Kong Enterprise Edition makes it fast and easy to configure caching of responses and serving of those cached responses to matching requests.
 
+  * [Detailed documentation for the EE Proxy Caching Plugin](/docs/enterprise/latest/plugins/http-proxy-caching/)
 ---

--- a/app/plugins/ee-rate-limiting.md
+++ b/app/plugins/ee-rate-limiting.md
@@ -11,4 +11,5 @@ breadcrumbs:
 description: |
   The Rate Limiting plugin for Kong Enterprise Edition is a re-engineered version of the incredibly popular Community Edition Rate Limiting plugin, with greatly enhanced configuration options and performance.
 
+  * [Detailed documentation for the EE Rate Limiting Plugin](/docs/enterprise/latest/plugins/rate-limiting-advanced/)
 ---

--- a/app/plugins/ee-request-transformer.md
+++ b/app/plugins/ee-request-transformer.md
@@ -1,8 +1,8 @@
 ---
 id: page-plugin
-title: Plugins - EE request Transformer
+title: Plugins - EE Request Transformer
 layout: plugin-ee
-header_title: EE request Transformer
+header_title: EE Request Transformer
 header_icon: /assets/images/icons/plugins/ee-request-transformer.png
 header_btn_text: Report Bug
 header_btn_href: mailto:support@konghq.com?subject={{ page.header_title }} Plugin Bug
@@ -11,4 +11,5 @@ breadcrumbs:
 description: |
   The Request Transformer plugin for Kong Enterprise Edition builds on the Community Edition version of this plugin with enhanced capabilities to match portions of incoming requests using regular expressions, save those matched strings into variables, and substitute those strings into transformed requests via flexible templates.
 
+  * [Detailed documentation for the EE Request Transformer Plugin](/docs/enterprise/latest/plugins/request-transformer)
 ---


### PR DESCRIPTION
It was annoying that you couldn't see links to the more explicit and detailed documentation that our amazing team has written. Now they are there.