### PR TITLE
docs(azure-functions and zipkin) remove ce/ee note

### DIFF
--- a/app/plugins/azure-functions.md
+++ b/app/plugins/azure-functions.md
@@ -95,8 +95,6 @@ params:
 
 ---
 
-> **Note**: Azure-Functions plugin is available in Enterprise as of version 0.32 and will soon be available as part of Kong CE 0.14.
-
 ## Demonstration
 
 To demonstrate the plugin, set up the [Azure Functions "hello world" function](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function).

--- a/app/plugins/zipkin.md
+++ b/app/plugins/zipkin.md
@@ -37,8 +37,6 @@ params:
 
 ---
 
-> **Note**: Zipkin plugin is available in Enterprise as of version 0.32 and will soon be available as part of Kong CE 0.14.
-
 ## How it Works
 
 When enabled, [this plugin](https://github.com/Kong/kong-plugin-zipkin) traces requests in a way compatible with [zipkin](https://zipkin.io/).


### PR DESCRIPTION
### Summary

Removes note about CE / EE, because as of Kong `0.14.0` both `azure-functions` and `zipkin` plugins will be include with Kong CE.